### PR TITLE
feat: add visualization capabilities for parsed documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,61 @@ for chunk in results[0].chunks:
 
 This feature works with all parsing functions: `parse_documents`, `parse_and_save_documents`, and `parse_and_save_document`.
 
+### Visualize Parsing Result
+
+The library provides a visualization utility that creates annotated images showing where each chunk of content was extracted from the document. This is useful for:
+- Verifying the accuracy of the extraction
+- Debugging extraction issues
+
+Here's how to use the visualization feature:
+
+```python
+from agentic_doc.parse import parse_documents
+from agentic_doc.utils import viz_parsed_document
+from agentic_doc.config import VisualizationConfig
+
+# Parse a document
+results = parse_documents(["path/to/document.pdf"])
+parsed_doc = results[0]
+
+# Create visualizations with default settings
+images = viz_parsed_document(
+    "path/to/document.pdf",
+    parsed_doc,
+    output_dir="path/to/save/visualizations"
+)
+
+# Or customize the visualization appearance
+viz_config = VisualizationConfig(
+    thickness=2,  # Thicker bounding boxes
+    text_bg_opacity=0.8,  # More opaque text background
+    font_scale=0.7,  # Larger text
+    # Custom colors for different chunk types
+    color_map={
+        "title": (0, 0, 255),  # Red for titles
+        "text": (255, 0, 0),  # Blue for regular text
+        # ... other chunk types ...
+    }
+)
+
+images = viz_parsed_document(
+    "path/to/document.pdf",
+    parsed_doc,
+    output_dir="path/to/save/visualizations",
+    viz_config=viz_config
+)
+
+# The visualization images will be saved as:
+# path/to/save/visualizations/document_viz_page_X.png
+# Where X is the page number
+```
+
+The visualization shows:
+- Bounding boxes around each extracted chunk
+- Chunk type and index labels
+- Different colors for different types of content (titles, text, tables, etc.)
+- Semi-transparent text backgrounds for better readability
+
 ### Automatically Handle API Errors and Rate Limits with Retries
 
 The REST API endpoint imposes rate limits per API key. This library automatically handles the rate limit error or other intermittent HTTP errors with retries.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ results = parse_documents(["path/to/document.pdf"])
 parsed_doc = results[0]
 
 # Create visualizations with default settings
+# The output images have a PIL.Image.Image type
 images = viz_parsed_document(
     "path/to/document.pdf",
     parsed_doc,

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ viz_config = VisualizationConfig(
     font_scale=0.7,  # Larger text
     # Custom colors for different chunk types
     color_map={
-        "title": (0, 0, 255),  # Red for titles
-        "text": (255, 0, 0),  # Blue for regular text
+        ChunkType.TITLE: (0, 0, 255),  # Red for titles
+        ChunkType.TEXT: (255, 0, 0),  # Blue for regular text
         # ... other chunk types ...
     }
 )

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -2,22 +2,57 @@ import json
 import logging
 from typing import Literal
 
+import cv2
 import structlog
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from agentic_doc.common import ChunkType
+
 _LOGGER = structlog.get_logger(__name__)
 _MAX_PARALLEL_TASKS = 100
+# Colors in BGR format (OpenCV uses BGR)
+_COLOR_MAP = {
+    ChunkType.title: (0, 0, 125),  # Dark red for titles
+    ChunkType.page_header: (0, 200, 200),  # Yellow-ish for headers
+    ChunkType.page_footer: (200, 200, 0),  # Cyan-ish for footers
+    ChunkType.page_number: (128, 128, 128),  # Gray for page numbers
+    ChunkType.key_value: (255, 0, 255),  # Magenta for key-value pairs
+    ChunkType.form: (128, 0, 255),  # Purple for forms
+    ChunkType.table: (139, 69, 19),  # Brown for tables
+    ChunkType.figure: (50, 205, 50),  # Lime green for figures
+    ChunkType.text: (255, 0, 0),  # Blue for regular text
+}
 
 
 class Settings(BaseSettings):
-    vision_agent_api_key: str = Field()
-    batch_size: int = Field(default=4)
-    max_workers: int = Field(default=5)
-    max_retries: int = Field(default=100)
-    max_retry_wait_time: int = Field(default=60)
+    vision_agent_api_key: str = Field(
+        description="API key for the vision agent",
+        default="",
+    )
+    batch_size: int = Field(
+        default=4,
+        description="Number of documents to process in parallel",
+        ge=1,
+    )
+    max_workers: int = Field(
+        default=5,
+        description="Maximum number of workers to use for parallel processing for each document",
+        ge=1,
+    )
+    max_retries: int = Field(
+        default=100,
+        description="Maximum number of retries for a failed request",
+        ge=0,
+    )
+    max_retry_wait_time: int = Field(
+        default=60,
+        description="Maximum wait time for a retry",
+        ge=0,
+    )
     retry_logging_style: Literal["none", "log_msg", "inline_block"] = Field(
-        default="log_msg"
+        default="log_msg",
+        description="Logging style for retries",
     )
     pdf_to_image_dpi: int = Field(
         default=96,
@@ -53,3 +88,45 @@ if settings.batch_size * settings.max_workers > _MAX_PARALLEL_TASKS:
 
 if settings.retry_logging_style == "inline_block":
     logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+class VisualizationConfig(BaseSettings):
+    thickness: int = Field(
+        default=1,
+        description="Thickness of the bounding box and text",
+        ge=0,
+    )
+    text_bg_color: tuple[int, int, int] = Field(
+        default=(211, 211, 211),  # Light gray
+        description="Background color of the text, in BGR format",
+    )
+    text_bg_opacity: float = Field(
+        default=0.7,
+        description="Opacity of the text background",
+        ge=0.0,
+        le=1.0,
+    )
+    padding: int = Field(
+        default=1,
+        description="Padding of the text background box",
+        ge=0,
+    )
+    font_scale: float = Field(
+        default=0.5,
+        description="Font scale of the text",
+        ge=0.0,
+    )
+    font: int = Field(
+        default=cv2.FONT_HERSHEY_SIMPLEX,
+        description="Font of the text",
+    )
+    color_map: dict[ChunkType, tuple[int, int, int]] = Field(
+        default=_COLOR_MAP,
+        description="Color map for each chunk type",
+    )
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_ignore_empty=True,
+        extra="ignore",
+    )

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -244,7 +244,7 @@ def viz_parsed_document(
     parsed_document: ParsedDocument,
     *,
     output_dir: Union[str, Path, None] = None,
-    viz_config: VisualizationConfig | None = None,
+    viz_config: Union[VisualizationConfig, None] = None,
 ) -> list[Image.Image]:
     if viz_config is None:
         viz_config = VisualizationConfig()
@@ -279,7 +279,7 @@ def viz_parsed_document(
 def viz_chunks(
     img: np.ndarray,
     chunks: list[Chunk],
-    viz_config: VisualizationConfig | None = None,
+    viz_config: Union[VisualizationConfig, None] = None,
 ) -> np.ndarray:
     if viz_config is None:
         viz_config = VisualizationConfig()

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -8,11 +8,18 @@ import cv2
 import numpy as np
 import pymupdf
 import structlog
+from PIL import Image
 from pypdf import PdfReader, PdfWriter
 from tenacity import RetryCallState
 
-from agentic_doc.common import Chunk, ChunkGroundingBox, ChunkType, Document
-from agentic_doc.config import settings
+from agentic_doc.common import (
+    Chunk,
+    ChunkGroundingBox,
+    ChunkType,
+    Document,
+    ParsedDocument,
+)
+from agentic_doc.config import VisualizationConfig, settings
 
 _LOGGER = structlog.getLogger(__name__)
 
@@ -83,6 +90,7 @@ def page_to_image(
     # Ensure the image has 3 channels (sometimes it may include an alpha channel)
     if img.shape[-1] == 4:  # If RGBA, drop the alpha channel
         img = img[..., :3]
+
     return img
 
 
@@ -229,3 +237,152 @@ def log_retry_failure(retry_state: RetryCallState) -> None:
             raise ValueError(
                 f"Invalid retry logging style: {settings.retry_logging_style}"
             )
+
+
+def viz_parsed_document(
+    file_path: Union[str, Path],
+    parsed_document: ParsedDocument,
+    *,
+    output_dir: Union[str, Path, None] = None,
+    viz_config: VisualizationConfig | None = None,
+) -> list[Image.Image]:
+    if viz_config is None:
+        viz_config = VisualizationConfig()
+
+    viz_result_np: list[np.ndarray] = []
+    file_path = Path(file_path)
+    file_type = get_file_type(file_path)
+    _LOGGER.info(f"Visualizing parsed document of: '{file_path}'")
+    if file_type == "image":
+        img = _read_img_rgb(str(file_path))
+        viz_np = viz_chunks(img, parsed_document.chunks, viz_config)
+        viz_result_np.append(viz_np)
+    else:
+        with pymupdf.open(file_path) as pdf_doc:
+            for page_idx in range(
+                parsed_document.start_page_idx, parsed_document.end_page_idx + 1
+            ):
+                img = page_to_image(pdf_doc, page_idx)
+                viz_np = viz_chunks(img, parsed_document.chunks, viz_config)
+                viz_result_np.append(viz_np)
+
+    if output_dir:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for i, viz_np in enumerate(viz_result_np):
+            viz_np = cv2.cvtColor(viz_np, cv2.COLOR_RGB2BGR)
+            cv2.imwrite(str(output_dir / f"{file_path.stem}_viz_page_{i}.png"), viz_np)
+
+    return [Image.fromarray(viz_np) for viz_np in viz_result_np]
+
+
+def viz_chunks(
+    img: np.ndarray,
+    chunks: list[Chunk],
+    viz_config: VisualizationConfig | None = None,
+) -> np.ndarray:
+    if viz_config is None:
+        viz_config = VisualizationConfig()
+
+    viz = img.copy()
+    height, width = img.shape[:2]
+    for i, chunk in enumerate(chunks):
+        bboxes: list[tuple[int, int, int, int]] = []
+        for grounding in chunk.grounding:
+            assert grounding.box is not None
+            xmin, ymin, xmax, ymax = (
+                max(0, math.floor(grounding.box.l * width)),
+                max(0, math.floor(grounding.box.t * height)),
+                min(width, math.ceil(grounding.box.r * width)),
+                min(height, math.ceil(grounding.box.b * height)),
+            )
+            box = (xmin, ymin, xmax, ymax)
+            bboxes.append(box)
+
+        if not bboxes:
+            _LOGGER.warning(f"Chunk {i} has no valid bounding boxes")
+            continue
+
+        combined_box = _combine_boxes(bboxes)
+        _place_mark(
+            viz,
+            combined_box,
+            text=f"{i} {chunk.chunk_type}",
+            color_bgr=viz_config.color_map[chunk.chunk_type],
+            viz_config=viz_config,
+        )
+
+    viz = cv2.cvtColor(viz, cv2.COLOR_BGR2RGB)
+    return viz
+
+
+def _combine_boxes(
+    bboxes: list[tuple[int, int, int, int]],
+) -> tuple[int, int, int, int]:
+    xmin = min(box[0] for box in bboxes)
+    ymin = min(box[1] for box in bboxes)
+    xmax = max(box[2] for box in bboxes)
+    ymax = max(box[3] for box in bboxes)
+    return (xmin, ymin, xmax, ymax)
+
+
+def _place_mark(
+    img: np.ndarray,
+    box_xyxy: tuple[int, int, int, int],
+    text: str,
+    *,
+    color_bgr: tuple[int, int, int],
+    viz_config: VisualizationConfig,
+) -> None:
+    text_color = color_bgr
+    (text_width, text_height), baseline = cv2.getTextSize(
+        text, viz_config.font, viz_config.font_scale, viz_config.thickness
+    )
+    text_x = int((box_xyxy[0] + box_xyxy[2] - text_width) // 2)
+    text_y = int((box_xyxy[1] + box_xyxy[3] + text_height) // 2)
+
+    # Draw the text background with opacity
+    overlay = img.copy()
+    cv2.rectangle(
+        overlay,
+        (text_x - viz_config.padding, text_y - text_height - viz_config.padding),
+        (
+            text_x + text_width + viz_config.padding,
+            text_y + baseline + viz_config.padding,
+        ),
+        viz_config.text_bg_color,
+        -1,
+    )
+    cv2.addWeighted(
+        overlay, viz_config.text_bg_opacity, img, 1 - viz_config.text_bg_opacity, 0, img
+    )
+
+    # Draw the text on top
+    cv2.putText(
+        img,
+        text,
+        (text_x, text_y),
+        viz_config.font,
+        viz_config.font_scale,
+        text_color,
+        viz_config.thickness,
+        cv2.LINE_AA,
+    )
+    # Draw the bounding box
+    cv2.rectangle(img, box_xyxy[:2], box_xyxy[2:], color_bgr, viz_config.thickness)
+
+
+def _read_img_rgb(img_path: str) -> np.ndarray:
+    """
+    Read a image given its path.
+    Arguments:
+        img_path : image file path
+    Returns:
+        img (H, W, 3): a numpy array image in RGB format
+    """
+    img = cv2.cvtColor(cv2.imread(img_path), cv2.COLOR_BGR2RGB)
+    if img.shape[-1] == 1:
+        img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+    elif img.shape[-1] == 4:
+        img = img[..., :3]
+    return img


### PR DESCRIPTION
## Changes

- Implemented `viz_parsed_document` and `viz_chunks` functions to visualize parsed documents and their chunks, allowing for customizable visual representation.
- Added `VisualizationConfig` class to manage visualization settings, including bounding box thickness, text background color, and opacity.

![output](https://github.com/user-attachments/assets/57614670-62c3-47b4-aba3-366c3d3c1c15)


