### PR TITLE
fix: handle input files with no pdf suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The `RETRY_LOGGING_STYLE` setting controls how the library logs the retry attemp
 
 ### Main Functions
 
-#### `parse_documents(documents: list[str | Path | AnyHttpUrl], *, grounding_save_dir: str | Path | None = None) -> list[ParsedDocument]`
+#### `parse_documents(documents: list[str | Path | Url], *, grounding_save_dir: str | Path | None = None) -> list[ParsedDocument]`
 
 Parse multiple documents and return their parsed results.
 
@@ -289,7 +289,7 @@ Parse multiple documents and return their parsed results.
   - `FileNotFoundError`: If any input file doesn't exist
   - `ValueError`: If any URL is invalid or points to an unsupported file type
 
-#### `parse_and_save_documents(documents: list[str | Path | AnyHttpUrl], *, result_save_dir: str | Path, grounding_save_dir: str | Path | None = None) -> list[Path]`
+#### `parse_and_save_documents(documents: list[str | Path | Url], *, result_save_dir: str | Path, grounding_save_dir: str | Path | None = None) -> list[Path]`
 
 Parse multiple documents and save results to the specified directory.
 
@@ -303,7 +303,7 @@ Parse multiple documents and save results to the specified directory.
   - `FileNotFoundError`: If any input file doesn't exist
   - `ValueError`: If any URL is invalid or points to an unsupported file type
 
-#### `parse_and_save_document(document: str | Path | AnyHttpUrl, *, result_save_dir: str | Path | None = None, grounding_save_dir: str | Path | None = None) -> Path | ParsedDocument`
+#### `parse_and_save_document(document: str | Path | Url, *, result_save_dir: str | Path | None = None, grounding_save_dir: str | Path | None = None) -> Path | ParsedDocument`
 
 Parse a single document and optionally save results.
 

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -9,7 +9,7 @@ from typing import Any, Union, cast
 import httpx
 import structlog
 import tenacity
-from pydantic import AnyHttpUrl
+from pydantic_core import Url
 from tqdm import tqdm
 
 from agentic_doc.common import (
@@ -34,7 +34,7 @@ _ENDPOINT_URL = "https://api.va.landing.ai/v1/tools/agentic-document-analysis"
 
 
 def parse_documents(
-    documents: list[Union[str, Path, AnyHttpUrl]],
+    documents: list[Union[str, Path, Url]],
     *,
     grounding_save_dir: Union[str, Path, None] = None,
 ) -> list[ParsedDocument]:
@@ -42,7 +42,7 @@ def parse_documents(
     Parse a list of documents using the Landing AI Agentic Document Analysis API.
 
     Args:
-        documents (list[str | Path | AnyHttpUrl]): The list of documents to parse. Each document can be a local file path, a URL string, or a Pydantic `AnyHttpUrl` object.
+        documents (list[str | Path | Url]): The list of documents to parse. Each document can be a local file path, a URL string, or a Pydantic `Url` object.
         grounding_save_dir (str | Path): The local directory to save the grounding images.
     Returns:
         list[ParsedDocument]: The list of parsed documents. The list is sorted by the order of the input documents.
@@ -63,7 +63,7 @@ def parse_documents(
 
 
 def parse_and_save_documents(
-    documents: list[Union[str, Path, AnyHttpUrl]],
+    documents: list[Union[str, Path, Url]],
     *,
     result_save_dir: Union[str, Path],
     grounding_save_dir: Union[str, Path, None] = None,
@@ -72,7 +72,7 @@ def parse_and_save_documents(
     Parse a list of documents and save the results to a local directory.
 
     Args:
-        documents (list[str | Path | AnyHttpUrl]): The list of documents to parse. Each document can be a local file path, a URL string, or a Pydantic `AnyHttpUrl` object.
+        documents (list[str | Path | Url]): The list of documents to parse. Each document can be a local file path, a URL string, or a Pydantic `Url` object.
         result_save_dir (str | Path): The local directory to save the results.
         grounding_save_dir (str | Path): The local directory to save the grounding images.
     Returns:
@@ -96,7 +96,7 @@ def parse_and_save_documents(
 
 
 def parse_and_save_document(
-    document: Union[str, Path, AnyHttpUrl],
+    document: Union[str, Path, Url],
     *,
     result_save_dir: Union[str, Path, None] = None,
     grounding_save_dir: Union[str, Path, None] = None,
@@ -105,7 +105,7 @@ def parse_and_save_document(
     Parse a document and save the results to a local directory.
 
     Args:
-        document (str | Path | AnyHttpUrl): The document to parse. It can be a local file path, a URL string, or a Pydantic `AnyHttpUrl` object.
+        document (str | Path | Url): The document to parse. It can be a local file path, a URL string, or a Pydantic `Url` object.
         result_save_dir (str | Path): The local directory to save the results. If None, the parsed document data is returned.
 
     Returns:
@@ -113,9 +113,9 @@ def parse_and_save_document(
     """
     with tempfile.TemporaryDirectory() as temp_dir:
         if isinstance(document, str) and is_valid_httpurl(document):
-            document = AnyHttpUrl(document)
+            document = Url(document)
 
-        if isinstance(document, AnyHttpUrl):
+        if isinstance(document, Url):
             output_file_path = Path(temp_dir) / Path(str(document)).name
             download_file(document, str(output_file_path))
             document = output_file_path

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -11,7 +11,7 @@ import numpy as np
 import pymupdf
 import structlog
 from PIL import Image
-from pydantic import AnyHttpUrl
+from pydantic_core import Url
 from pypdf import PdfReader, PdfWriter
 from tenacity import RetryCallState
 
@@ -28,8 +28,21 @@ _LOGGER = structlog.getLogger(__name__)
 
 
 def get_file_type(file_path: Path) -> Literal["pdf", "image"]:
-    """Get the file type of the input file."""
-    return "pdf" if file_path.suffix.lower() == ".pdf" else "image"
+    """Get the file type of the input file by checking its magic number.
+
+    PDF files start with '%PDF-' (25 50 44 46 2D in hex)
+    """
+    try:
+        with open(file_path, 'rb') as f:
+            # Read the first 5 bytes to check for PDF magic number
+            header = f.read(5)
+            if header == b'%PDF-':
+                return "pdf"
+            return "image"
+    except Exception as e:
+        _LOGGER.warning(f"Error checking file type: {e}")
+        # Fallback to extension check if file reading fails
+        return "pdf" if file_path.suffix.lower() == ".pdf" else "image"
 
 
 def save_groundings_as_images(
@@ -177,7 +190,6 @@ def split_pdf(
     """
     input_pdf_path = Path(input_pdf_path)
     assert input_pdf_path.exists(), f"Input PDF file not found: {input_pdf_path}"
-    assert input_pdf_path.suffix == ".pdf", "Input file must be a PDF"
     assert (
         0 < split_size <= 2
     ), "split_size must be greater than 0 and less than or equal to 2"
@@ -381,12 +393,12 @@ def _read_img_rgb(img_path: str) -> np.ndarray:
     return img
 
 
-def download_file(file_url: AnyHttpUrl, output_filepath: str) -> None:
+def download_file(file_url: Url, output_filepath: str) -> None:
     """
     Downloads a file from the given media URL to the specified local path.
 
     Parameters:
-    media_url (AnyHttpUrl): The URL of the media file to download.
+    media_url (Url): The URL of the media file to download.
     path (str): The local file system path where the file should be saved.
 
     Raises:

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -33,10 +33,10 @@ def get_file_type(file_path: Path) -> Literal["pdf", "image"]:
     PDF files start with '%PDF-' (25 50 44 46 2D in hex)
     """
     try:
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             # Read the first 5 bytes to check for PDF magic number
             header = f.read(5)
-            if header == b'%PDF-':
+            if header == b"%PDF-":
                 return "pdf"
             return "image"
     except Exception as e:


### PR DESCRIPTION
1. Support input file or url with no ".pdf" suffix, e.g. "'https://arxiv.org/pdf/2201.04234"
2. Fix a type checking bug
