### PR TITLE
chore: minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ results = parse_documents(
 )
 
 # The grounding images will be saved to:
-# path/to/save/groundings/document_TIMESTAMP/page_X/CHUNK_ID_Y.png
+# path/to/save/groundings/document_TIMESTAMP/page_X/CHUNK_TYPE_CHUNK_ID_Y.png
 # Where X is the page number, CHUNK_ID is the unique ID of each chunk,
 # and Y is the index of the grounding within the chunk
 

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -10,7 +10,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from agentic_doc.common import ChunkType
 
 _LOGGER = structlog.get_logger(__name__)
-_MAX_PARALLEL_TASKS = 100
+_MAX_PARALLEL_TASKS = 200
 # Colors in BGR format (OpenCV uses BGR)
 _COLOR_MAP = {
     ChunkType.title: (0, 0, 125),  # Dark red for titles

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -140,7 +140,7 @@ def _crop_groundings(
                 continue
 
             page = f"page_{grounding.page}"
-            crop_save_path = crop_save_dir / page / f"{c.chunk_id}_{i}.png"
+            crop_save_path = crop_save_dir / page / f"{c.chunk_type}_{c.chunk_id}_{i}.png"
             crop_save_path.parent.mkdir(parents=True, exist_ok=True)
             crop_save_path.write_bytes(buffer.tobytes())
             assert c.chunk_id is not None


### PR DESCRIPTION
1. Include chunk_type in the file name of the saved grounding image
2. Double max parallel task limit to account for increased rate limit