### PR TITLE
Add split size

### DIFF
--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
         ge=1,
     )
     split_size: int = Field(
-        default=2,
+        default=10,
         description="Pages per chunk for splitting the document",
         ge=1,
         le=50,

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -63,7 +63,11 @@ class Settings(BaseSettings):
         description="DPI for converting PDF pages to images",
         ge=1,
     )
-
+    split_size: int = Field(
+        default=2,
+        description="Pages per chunk for splitting the document",
+        ge=1,
+    )
     model_config = SettingsConfigDict(
         env_file=".env",
         env_ignore_empty=True,

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
         default=2,
         description="Pages per chunk for splitting the document",
         ge=1,
+        le=50,
     )
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -155,7 +155,7 @@ def parse_and_save_document(
 
 def _parse_pdf(file_path: Union[str, Path]) -> ParsedDocument:
     with tempfile.TemporaryDirectory() as temp_dir:
-        parts = split_pdf(file_path, temp_dir)
+        parts = split_pdf(file_path, temp_dir, settings.split_size)
         file_path = Path(file_path)
         part_results = _parse_doc_in_parallel(parts, doc_name=file_path.name)
         return _merge_part_results(part_results)

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -180,7 +180,7 @@ def _crop_image(image: np.ndarray, bbox: ChunkGroundingBox) -> np.ndarray:
 def split_pdf(
     input_pdf_path: Union[str, Path],
     output_dir: Union[str, Path],
-    split_size: int = 2,
+    split_size: int = 10,
 ) -> list[Document]:
     """
     Splits a PDF file into smaller PDFs, each with at most max_pages pages.
@@ -188,13 +188,13 @@ def split_pdf(
     Args:
         input_pdf_path (str | Path): Path to the input PDF file.
         output_dir (str | Path): Directory where mini PDF files will be saved.
-        split_size (int): Maximum number of pages per mini PDF file (default is 2, which is the server endpoint's limit).
+        split_size (int): Maximum number of pages per mini PDF file (default is 10).
     """
     input_pdf_path = Path(input_pdf_path)
     assert input_pdf_path.exists(), f"Input PDF file not found: {input_pdf_path}"
     assert (
-        0 < split_size <= 2
-    ), "split_size must be greater than 0 and less than or equal to 2"
+        0 < split_size <= 50
+    ), "split_size must be greater than 0 and less than or equal to 50"
 
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     output_dir = str(output_dir)


### PR DESCRIPTION
Adds split_size as a configurable parameter, and passes it to the parse_pdf function to be able to parse pdfs in chunks or more than 2 pages.