### PR TITLE
breaking: remove unused chunk_type

### DIFF
--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -13,9 +13,6 @@ class ChunkType(str, Enum):
     text = "text"
     marginalia = "marginalia"
 
-    # Below values are deprecated
-    page_header = "page_header"
-
 
 class ChunkGroundingBox(BaseModel):
     """

--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -32,8 +32,7 @@ class ChunkGroundingBox(BaseModel):
 
 class ChunkGrounding(BaseModel):
     page: int
-    # NOTE: could be None if error happens in parsing the chunk
-    box: Union[ChunkGroundingBox, None]
+    box: ChunkGroundingBox
     # NOTE: image_path doesn't come from the server API, so it's null by default
     image_path: Union[Path, None] = None
 
@@ -42,16 +41,7 @@ class Chunk(BaseModel):
     text: str
     grounding: list[ChunkGrounding]
     chunk_type: ChunkType
-    chunk_id: Union[str, None]
-
-    @staticmethod
-    def error_chunk(error_msg: str, page_idx: int) -> "Chunk":
-        return Chunk(
-            text=error_msg,
-            grounding=[ChunkGrounding(page=page_idx, box=None)],
-            chunk_type=ChunkType.error,
-            chunk_id=None,
-        )
+    chunk_id: str
 
 
 class PageError(BaseModel):

--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -8,19 +8,13 @@ from pydantic import BaseModel, Field
 
 
 class ChunkType(str, Enum):
-    form = "form"
     table = "table"
     figure = "figure"
     text = "text"
     marginalia = "marginalia"
 
     # Below values are deprecated
-    error = "error"
-    title = "title"  # type: ignore [assignment]
     page_header = "page_header"
-    page_footer = "page_footer"
-    page_number = "page_number"
-    key_value = "key_value"
 
 
 class ChunkGroundingBox(BaseModel):

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -13,12 +13,8 @@ _LOGGER = structlog.get_logger(__name__)
 _MAX_PARALLEL_TASKS = 200
 # Colors in BGR format (OpenCV uses BGR)
 _COLOR_MAP = {
-    ChunkType.title: (0, 0, 125),  # Dark red for titles
     ChunkType.page_header: (0, 200, 200),  # Yellow-ish for headers
-    ChunkType.page_footer: (200, 200, 0),  # Cyan-ish for footers
-    ChunkType.page_number: (128, 128, 128),  # Gray for page numbers
-    ChunkType.key_value: (255, 0, 255),  # Magenta for key-value pairs
-    ChunkType.form: (128, 0, 255),  # Purple for forms
+    ChunkType.marginalia: (128, 0, 255),  # Purple for marginalia
     ChunkType.table: (139, 69, 19),  # Brown for tables
     ChunkType.figure: (50, 205, 50),  # Lime green for figures
     ChunkType.text: (255, 0, 0),  # Blue for regular text

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -13,7 +13,6 @@ _LOGGER = structlog.get_logger(__name__)
 _MAX_PARALLEL_TASKS = 200
 # Colors in BGR format (OpenCV uses BGR)
 _COLOR_MAP = {
-    ChunkType.page_header: (0, 200, 200),  # Yellow-ish for headers
     ChunkType.marginalia: (128, 0, 255),  # Purple for marginalia
     ChunkType.table: (139, 69, 19),  # Brown for tables
     ChunkType.figure: (50, 205, 50),  # Lime green for figures

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -1,4 +1,5 @@
 import copy
+import importlib.metadata
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -31,6 +32,7 @@ from agentic_doc.utils import (
 
 _LOGGER = structlog.getLogger(__name__)
 _ENDPOINT_URL = f"{settings.endpoint_host}/v1/tools/agentic-document-analysis"
+_LIB_VERSION = importlib.metadata.version("agentic-doc")
 
 
 def parse_documents(
@@ -352,7 +354,7 @@ def _send_parsing_request(
             }
             headers = {
                 "Authorization": f"Basic {settings.vision_agent_api_key}",
-                "runtime_tag": "agentic-doc",
+                "runtime_tag": f"agentic-doc-v{_LIB_VERSION}",
             }
             response = httpx.post(
                 _ENDPOINT_URL,

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -18,7 +18,6 @@ from tenacity import RetryCallState
 from agentic_doc.common import (
     Chunk,
     ChunkGroundingBox,
-    ChunkType,
     Document,
     ParsedDocument,
 )

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -78,9 +78,6 @@ def save_groundings_as_images(
     assert file_type == "pdf"
     chunks_by_page_idx = defaultdict(list)
     for chunk in chunks:
-        if chunk.chunk_type == ChunkType.error:
-            continue
-
         page_idx = chunk.grounding[0].page
         chunks_by_page_idx[page_idx].append(chunk)
 
@@ -118,8 +115,6 @@ def _crop_groundings(
 ) -> dict[str, list[Path]]:
     result: dict[str, list[Path]] = defaultdict(list)
     for c in chunks:
-        if c.chunk_type == ChunkType.error:
-            continue
         for i, grounding in enumerate(c.grounding):
             if grounding.box is None:
                 _LOGGER.error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "agentic-doc"
-version = "0.1.3"
+version = "0.2.0"
 description = "A Python library that wraps around VisionAgent document extraction REST API to make documents extraction easy."
 authors = ["Landing AI <dev@landing.ai>"]
 readme = "README.md"

--- a/tests/integ/test_parse_integ.py
+++ b/tests/integ/test_parse_integ.py
@@ -32,8 +32,7 @@ def test_parse_and_save_documents_multiple_inputs(sample_image_path, results_dir
         assert len(parsed_doc.chunks) > 0
         assert parsed_doc.start_page_idx == 0
         assert parsed_doc.end_page_idx == 0
-        for chunk in parsed_doc.chunks:
-            assert chunk.chunk_type != ChunkType.error
+        assert len(parsed_doc.errors) == 0
 
 
 def test_parse_and_save_documents_single_pdf(sample_pdf_path, results_dir):
@@ -66,12 +65,14 @@ def test_parse_and_save_documents_single_pdf(sample_pdf_path, results_dir):
     for i in range(1, len(parsed_doc.chunks)):
         prev_page = parsed_doc.chunks[i - 1].grounding[0].page
         curr_page = parsed_doc.chunks[i].grounding[0].page
-        assert (
-            curr_page >= prev_page
-        ), f"Chunks not ordered by page: chunk {i - 1} (page {prev_page}) followed by chunk {i} (page {curr_page})"
+        assert curr_page >= prev_page, (
+            f"Chunks not ordered by page: chunk {i - 1} (page {prev_page}) followed by chunk {i} (page {curr_page})"
+        )
+
+    # Verify that there were no errors
+    assert len(parsed_doc.errors) == 0
 
     # Verify that grounding images were saved
     for chunk in parsed_doc.chunks:
-        assert chunk.chunk_type != ChunkType.error
         for grounding in chunk.grounding:
             assert grounding.image_path.exists()


### PR DESCRIPTION
## Changes

1. Remove unused chunk_type enums in the upcoming REST API release
2. Track library version in the header