### PR TITLE
Handle api key and document url error

### DIFF
--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -132,9 +132,13 @@ def parse_and_save_document(
             try:
                 download_file(document, str(output_file_path))
             except Exception as e:
-                _LOGGER.error(f"Failed to download file from URL: {document} due to: {e}")
-                raise RuntimeError(f"Could not download file from URL: {document}") from e
-            
+                _LOGGER.error(
+                    f"Failed to download file from URL: {document} due to: {e}"
+                )
+                raise RuntimeError(
+                    f"Could not download file from URL: {document}"
+                ) from e
+
             document = output_file_path
         else:
             document = Path(document)

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -373,7 +373,9 @@ def _send_parsing_request(
                 timeout=None,
             )
             if response.status_code == 401:
-                raise RuntimeError("Invalid API key")
+                raise RuntimeError(
+                    "Please confirm that the API key is generated and set correctly"
+                )
             if response.status_code in [408, 429, 502, 503, 504]:
                 raise RetryableError(response)
 

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -129,7 +129,12 @@ def parse_and_save_document(
 
         if isinstance(document, Url):
             output_file_path = Path(temp_dir) / Path(str(document)).name
-            download_file(document, str(output_file_path))
+            try:
+                download_file(document, str(output_file_path))
+            except Exception as e:
+                _LOGGER.error(f"Failed to download file from URL: {document} due to: {e}")
+                raise RuntimeError(f"Could not download file from URL: {document}") from e
+            
             document = output_file_path
         else:
             document = Path(document)
@@ -363,6 +368,8 @@ def _send_parsing_request(
                 headers=headers,
                 timeout=None,
             )
+            if response.status_code == 401:
+                raise RuntimeError("Invalid API key")
             if response.status_code in [408, 429, 502, 503, 504]:
                 raise RetryableError(response)
 


### PR DESCRIPTION
Updated to handle cases 
1. User provides a valid https link but unable to download file.
2. If the API key provided by user is invalid.