### PR TITLE
fix: set utf-8 encoding when writing response

### DIFF
--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -427,7 +427,7 @@ def parse_and_save_document(
         result_save_dir = Path(result_save_dir)
         result_save_dir.mkdir(parents=True, exist_ok=True)
         save_path = result_save_dir / f"{result_name}.json"
-        save_path.write_text(result.model_dump_json())
+        save_path.write_text(result.model_dump_json(), encoding="utf-8")
         _LOGGER.info(f"Saved the parsed result to '{save_path}'")
 
         return save_path


### PR DESCRIPTION
on Windows machines, the default encoding fails to write json files when it has some special characters. this pr sets utf-8 as default encoding when saving json files.