### PR TITLE
fix: field extraction api errors are not being forwarded correctly

### DIFF
--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -489,6 +489,7 @@ def _parse_image(
         result_raw = {
             **result_raw["data"],
             "errors": result_raw.get("errors", []),
+            "extraction_error": result_raw.get("extraction_error", None),
             "doc_type": "image",
             "start_page_idx": 0,
             "end_page_idx": 0,
@@ -626,6 +627,7 @@ def _parse_doc_parts(
         result_data = {
             **result["data"],
             "errors": result.get("errors", []),
+            "extraction_error": result.get("extraction_error", None),
             "start_page_idx": doc.start_page_idx,
             "end_page_idx": doc.end_page_idx,
             "doc_type": "pdf",


### PR DESCRIPTION
Description
---

* When using the SDK with field extraction, if we have any error with field extraction, we don't get any message when looking into the `parse` results e.g `results[0].extraction_errors`
* This PR fixes this problem by correctly forwarding the errors thrown by the API.
* Add unit test to check that the error messages are forwarded correctly to the parse results.

Screenshots
---
Error is shown correctly

![Screenshot 2025-06-24 at 8 09 38 PM](https://github.com/user-attachments/assets/d8e4449f-e2c1-424f-bb2f-50ef5fad0a28)
