### PR TITLE
feat: expand metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Main Branch CI
 
 on:
   push:
@@ -39,11 +39,9 @@ jobs:
           poetry run pip -V
       - name: Install dependencies
         run: |
-          # Install main dependencies first so we can see their size
           poetry install --all-extras
       - name: Linting
         run: |
-          # stop the build if there are Python syntax errors or undefined names
           poetry run flake8 . --exclude .venv,examples,tests --count --show-source --statistics
       - name: Check Format
         run: |
@@ -80,46 +78,7 @@ jobs:
           poetry run pip -V
       - name: Install dependencies
         run: |
-          # Install main dependencies first so we can see their size
           poetry install --all-extras
       - name: Integ Test with pytest
         run: |
           poetry run pytest -n auto -s -vvv tests/integ
-
-
-  release:
-    name: Release
-    needs: unit_test
-    # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):') && !contains(github.event.head_commit.message, '[skip release]')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.10.11
-      - name: Install Python Poetry
-        uses: abatilo/actions-poetry@v2.1.0
-        with:
-          poetry-version: 1.4.2
-      - name: Configure poetry
-        shell: bash
-        run: poetry config virtualenvs.in-project true
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: setup git config
-        run: |
-          git config user.name "Landing AI Bot"
-          git config user.email "dev@landing.ai"
-      - name: Bump up version
-        run: |
-          poetry version patch
-          git add pyproject.toml
-          new_version=`poetry version`
-          git commit -m "[skip ci] chore(release): ${new_version}"
-          git push -f
-      - name: Publish to PyPI
-        run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-          poetry publish --build -vvv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release Branch CI/CD
+
+on:
+  push:
+    branches: [release]
+
+env:
+  VISION_AGENT_API_KEY: "PLACEHOLDER"
+  PYTHONUTF8: 1
+
+jobs:
+  unit_test:
+    name: Test
+    strategy:
+      matrix:
+        python-version: [3.9, 3.13]
+        os: [ubuntu-22.04, windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
+    env:
+      RUNTIME_TAG: ci_job
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python Poetry
+        uses: abatilo/actions-poetry@v2.1.0
+        with:
+          poetry-version: 1.4.2
+      - name: Configure poetry
+        shell: bash
+        run: poetry config virtualenvs.in-project true
+      - name: Print Python environment information
+        run: |
+          poetry env info
+          poetry --version
+          poetry run pip -V
+      - name: Install dependencies
+        run: |
+          poetry install --all-extras
+      - name: Linting
+        run: |
+          poetry run flake8 . --exclude .venv,examples,tests --count --show-source --statistics
+      - name: Check Format
+        run: |
+          poetry run black --check --diff --color agentic_doc/
+      - name: Type Checking
+        run: |
+          poetry run mypy agentic_doc
+      - name: Test with pytest
+        run: |
+          poetry run pytest -s -vvv tests/unit
+
+  integ_test:
+    name: Integ Test
+    runs-on: ubuntu-latest
+    env:
+      RUNTIME_TAG: ci_job
+      VISION_AGENT_API_KEY: ${{ secrets.VISION_AGENT_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+      - name: Install Python Poetry
+        uses: abatilo/actions-poetry@v2.1.0
+        with:
+          poetry-version: 1.4.2
+      - name: Configure poetry
+        shell: bash
+        run: poetry config virtualenvs.in-project true
+      - name: Print Python environment information
+        run: |
+          poetry env info
+          poetry --version
+          poetry run pip -V
+      - name: Install dependencies
+        run: |
+          poetry install --all-extras
+      - name: Integ Test with pytest
+        run: |
+          poetry run pytest -n auto -s -vvv tests/integ
+
+  release:
+    name: Release to PyPI
+    needs: [unit_test, integ_test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.10.11
+      - name: Install Python Poetry
+        uses: abatilo/actions-poetry@v2.1.0
+        with:
+          poetry-version: 1.4.2
+      - name: Configure poetry
+        shell: bash
+        run: poetry config virtualenvs.in-project true
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: setup git config
+        run: |
+          git config user.name "Landing AI Bot"
+          git config user.email "dev@landing.ai"
+      - name: Bump up version
+        run: |
+          poetry version patch
+          git add pyproject.toml
+          new_version=`poetry version`
+          git commit -m "[skip ci] chore(release): ${new_version}"
+          git push -f
+      - name: Publish to PyPI
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry publish --build -vvv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           git config user.email "dev@landing.ai"
       - name: Bump up version
         run: |
-          poetry version patch
+          poetry version ${{ github.ref_name }}
           git add pyproject.toml
           new_version=`poetry version`
           git commit -m "[skip ci] chore(release): ${new_version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release Branch CI/CD
 
 on:
-  push:
-    branches: [release]
+  release:
+    types: [created]
 
 env:
   VISION_AGENT_API_KEY: "PLACEHOLDER"

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -16,6 +16,7 @@ from pydantic_core import Url
 from tqdm import tqdm
 import jsonschema
 from pypdf import PdfReader
+import os
 
 from agentic_doc.common import (
     Document,
@@ -86,6 +87,7 @@ def parse(
     Returns:
         List[ParsedDocument]
     """
+    settings.vision_agent_api_key = os.getenv("VISION_AGENT_API_KEY", "")
     check_endpoint_and_api_key(_ENDPOINT_URL)
 
     # Convert input to list of document paths

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -32,7 +32,7 @@ def check_endpoint_and_api_key(endpoint_url: str) -> None:
     headers = {"Authorization": f"Basic {api_key}"}
 
     try:
-        response = requests.get(endpoint_url, headers=headers, timeout=5)
+        response = requests.head(endpoint_url, headers=headers, timeout=5)
     except requests.exceptions.ConnectionError:
         raise ValueError(f'The endpoint URL "{endpoint_url}" is down or invalid.')
 

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -2,7 +2,7 @@ import math
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal, Union, Optional
 from urllib.parse import urlparse
 
 import cv2
@@ -122,6 +122,10 @@ def page_to_image(
         img = img[..., :3]
 
     return img
+
+
+def get_chunk_from_reference(chunk_id: str, chunks: list[dict]) -> Optional[dict]:
+    return next((chunk for chunk in chunks if chunk.get("chunk_id") == chunk_id), None)
 
 
 def _crop_groundings(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "agentic-doc"
-version = "0.2.10"
+version = "0.3.0"
 description = "A Python library that wraps around VisionAgent document extraction REST API to make documents extraction easy."
 authors = ["Landing AI <dev@landing.ai>"]
 readme = "README.md"

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -13,6 +13,7 @@ from agentic_doc.common import (
     ChunkType,
     Document,
     ParsedDocument,
+    MetadataType,
 )
 from agentic_doc.connectors import (
     LocalConnector,
@@ -1055,12 +1056,12 @@ class TestParseFunctionConsolidated:
             assert metadata is not None
 
             # Check that metadata fields are dict[str, list[str]]
-            assert isinstance(metadata.name, dict)
-            assert isinstance(metadata.age, dict)
+            assert isinstance(metadata.name, MetadataType)
+            assert isinstance(metadata.age, MetadataType)
 
             # Check specific metadata values
-            assert metadata.name["chunk_references"] == ["high"]
-            assert metadata.age["chunk_references"] == ["medium"]
+            assert metadata.name.chunk_references == ["high"]
+            assert metadata.age.chunk_references == ["medium"]
 
     def test_extraction_metadata_with_nested_models(self, sample_image_path):
         """Test extraction_metadata functionality with nested models."""
@@ -1115,17 +1116,17 @@ class TestParseFunctionConsolidated:
             metadata = result[0].extraction_metadata
             assert metadata is not None
 
-            assert isinstance(metadata.name, dict)
-            assert metadata.name["chunk_references"] == ["high"]
+            assert isinstance(metadata.name, MetadataType)
+            assert metadata.name.chunk_references == ["high"]
 
             assert hasattr(metadata, "address")
             assert hasattr(metadata.address, "street")
             assert hasattr(metadata.address, "city")
 
-            assert isinstance(metadata.address.street, dict)
-            assert isinstance(metadata.address.city, dict)
-            assert metadata.address.street["chunk_references"] == ["medium"]
-            assert metadata.address.city["chunk_references"] == ["high"]
+            assert isinstance(metadata.address.street, MetadataType)
+            assert isinstance(metadata.address.city, MetadataType)
+            assert metadata.address.street.chunk_references == ["medium"]
+            assert metadata.address.city.chunk_references == ["high"]
 
     def test_extraction_metadata_with_optional_fields(self, sample_image_path):
         """Test extraction_metadata functionality with optional fields."""
@@ -1176,12 +1177,12 @@ class TestParseFunctionConsolidated:
             metadata = result[0].extraction_metadata
             assert metadata is not None
 
-            assert isinstance(metadata.name, dict)
-            assert metadata.name["chunk_references"] == ["high"]
+            assert isinstance(metadata.name, MetadataType)
+            assert metadata.name.chunk_references == ["high"]
 
             assert metadata.phone is None  # Optional field with no data should be None
-            assert isinstance(metadata.email, dict)
-            assert metadata.email["chunk_references"] == ["medium"]
+            assert isinstance(metadata.email, MetadataType)
+            assert metadata.email.chunk_references == ["medium"]
 
     def test_extraction_metadata_with_list_fields(self, sample_image_path):
         """Test extraction_metadata functionality with list fields."""
@@ -1246,23 +1247,23 @@ class TestParseFunctionConsolidated:
             metadata = result[0].extraction_metadata
             assert metadata is not None
 
-            assert isinstance(metadata.name, dict)
-            assert metadata.name["chunk_references"] == ["high"]
+            assert isinstance(metadata.name, MetadataType)
+            assert metadata.name.chunk_references == ["high"]
 
             assert isinstance(metadata.skills, list)
             assert len(metadata.skills) == 2
 
             first_skill_meta = metadata.skills[0]
-            assert isinstance(first_skill_meta.name, dict)
-            assert isinstance(first_skill_meta.level, dict)
-            assert first_skill_meta.name["chunk_references"] == ["high"]
-            assert first_skill_meta.level["chunk_references"] == ["high"]
+            assert isinstance(first_skill_meta.name, MetadataType)
+            assert isinstance(first_skill_meta.level, MetadataType)
+            assert first_skill_meta.name.chunk_references == ["high"]
+            assert first_skill_meta.level.chunk_references == ["high"]
 
             second_skill_meta = metadata.skills[1]
-            assert isinstance(second_skill_meta.name, dict)
-            assert isinstance(second_skill_meta.level, dict)
-            assert second_skill_meta.name["chunk_references"] == ["high"]
-            assert second_skill_meta.level["chunk_references"] == ["medium"]
+            assert isinstance(second_skill_meta.name, MetadataType)
+            assert isinstance(second_skill_meta.level, MetadataType)
+            assert second_skill_meta.name.chunk_references == ["high"]
+            assert second_skill_meta.level.chunk_references == ["medium"]
 
     def test_extraction_metadata_error(self, sample_image_path):
         """Test extraction_metadata error."""
@@ -1330,10 +1331,16 @@ class TestParseFunctionConsolidated:
         extraction_schema = {
             "type": "object",
             "properties": {
-                "employee_name": {"type": "string", "description": "the full name of the employee"},
-                "gross_pay": {"type": "number", "description": "the gross pay of the employee"}
+                "employee_name": {
+                    "type": "string",
+                    "description": "the full name of the employee",
+                },
+                "gross_pay": {
+                    "type": "number",
+                    "description": "the gross pay of the employee",
+                },
             },
-            "required": ["employee_name", "gross_pay"]
+            "required": ["employee_name", "gross_pay"],
         }
 
         with patch(
@@ -1358,9 +1365,9 @@ class TestParseFunctionConsolidated:
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Person's name"},
-                "age": {"type": "integer", "description": "Person's age"}
+                "age": {"type": "integer", "description": "Person's age"},
             },
-            "required": ["name", "age"]
+            "required": ["name", "age"],
         }
 
         with patch("agentic_doc.parse._send_parsing_request") as mock_request:
@@ -1403,9 +1410,9 @@ class TestParseFunctionConsolidated:
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Person's name"},
-                "age": {"type": "integer", "description": "Person's age"}
+                "age": {"type": "integer", "description": "Person's age"},
             },
-            "required": ["name", "age"]
+            "required": ["name", "age"],
         }
 
         with patch("agentic_doc.parse._send_parsing_request") as mock_request:
@@ -1426,7 +1433,10 @@ class TestParseFunctionConsolidated:
                             "chunk_id": "1",
                         }
                     ],
-                    "extracted_schema": {"name": "John Doe", "age": "thirty"},  # Invalid: age should be integer
+                    "extracted_schema": {
+                        "name": "John Doe",
+                        "age": "thirty",
+                    },  # Invalid: age should be integer
                 },
                 "errors": [],
             }
@@ -1442,9 +1452,9 @@ class TestParseFunctionConsolidated:
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Person's name"},
-                "age": {"type": "integer", "description": "Person's age"}
+                "age": {"type": "integer", "description": "Person's age"},
             },
-            "required": ["name"]
+            "required": ["name"],
         }
         extraction_error_msg = "Failed to extract the fields from the input schema. Error: Invalid schema - All object keys must be required at root. Expected required=['name', 'age'], got required=['name']"
 
@@ -1487,9 +1497,9 @@ class TestParseFunctionConsolidated:
                     "type": "object",
                     "properties": {
                         "street": {"type": "string", "description": "Street address"},
-                        "city": {"type": "string", "description": "City"}
+                        "city": {"type": "string", "description": "City"},
                     },
-                    "required": ["street", "city"]
+                    "required": ["street", "city"],
                 },
                 "skills": {
                     "type": "array",
@@ -1497,13 +1507,13 @@ class TestParseFunctionConsolidated:
                         "type": "object",
                         "properties": {
                             "name": {"type": "string", "description": "Skill name"},
-                            "level": {"type": "string", "description": "Skill level"}
+                            "level": {"type": "string", "description": "Skill level"},
                         },
-                        "required": ["name", "level"]
-                    }
-                }
+                        "required": ["name", "level"],
+                    },
+                },
             },
-            "required": ["name", "address", "skills"]
+            "required": ["name", "address", "skills"],
         }
 
         with patch("agentic_doc.parse._send_parsing_request") as mock_request:
@@ -1525,14 +1535,11 @@ class TestParseFunctionConsolidated:
                     ],
                     "extracted_schema": {
                         "name": "Alice Brown",
-                        "address": {
-                            "street": "123 Main St",
-                            "city": "Springfield"
-                        },
+                        "address": {"street": "123 Main St", "city": "Springfield"},
                         "skills": [
                             {"name": "Python", "level": "Expert"},
-                            {"name": "Java", "level": "Intermediate"}
-                        ]
+                            {"name": "Java", "level": "Intermediate"},
+                        ],
                     },
                     "extraction_metadata": {
                         "name": {"chunk_references": ["high"]},
@@ -1583,14 +1590,23 @@ class TestParseFunctionConsolidated:
             "type": "object",
             "properties": {
                 "employee_name": {"type": "string"},
-                "gross_pay": {"type": "number"}
-            }
+                "gross_pay": {"type": "number"},
+            },
         }
 
-        with pytest.raises(ValueError, match="extraction_model and extraction_schema cannot be used together"):
-            parse(test_file, extraction_model=EmployeeFields, extraction_schema=extraction_schema)
+        with pytest.raises(
+            ValueError,
+            match="extraction_model and extraction_schema cannot be used together",
+        ):
+            parse(
+                test_file,
+                extraction_model=EmployeeFields,
+                extraction_schema=extraction_schema,
+            )
 
-    def test_parse_with_neither_extraction_model_nor_schema(self, temp_dir, mock_parsed_document):
+    def test_parse_with_neither_extraction_model_nor_schema(
+        self, temp_dir, mock_parsed_document
+    ):
         """Test parsing without any extraction model or schema."""
         test_file = temp_dir / "test.pdf"
         with open(test_file, "wb") as f:
@@ -1611,4 +1627,3 @@ class TestParseFunctionConsolidated:
                 extraction_model=None,
                 extraction_schema=None,
             )
-

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -42,6 +42,7 @@ from agentic_doc.utils import (
     split_pdf,
     viz_chunks,
     viz_parsed_document,
+    get_chunk_from_reference,
 )
 
 
@@ -862,3 +863,34 @@ def test_log_retry_failure_with_different_attempt_numbers(monkeypatch):
 
         # Should not raise an exception regardless of attempt number
         log_retry_failure(retry_state)
+
+
+def test_get_chunk_from_reference():
+    chunks = [
+        {
+            "text": "Name: Bob Johnson",
+            "grounding": [
+                {
+                    "page": 0,
+                    "box": {"l": 0.1, "t": 0.1, "r": 0.9, "b": 0.2},
+                }
+            ],
+            "chunk_type": "text",
+            "chunk_id": "1",
+        },
+        {
+            "text": "Name: Alice Smith",
+            "grounding": [
+                {
+                    "page": 1,
+                    "box": {"l": 0.2, "t": 0.2, "r": 0.8, "b": 0.3},
+                }
+            ],
+            "chunk_type": "text",
+            "chunk_id": "2",
+        },
+    ]
+
+    result = get_chunk_from_reference("1", chunks)
+    assert result["text"] == "Name: Bob Johnson"
+    assert get_chunk_from_reference("999", chunks) == None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -90,7 +90,7 @@ def test_check_endpoint_and_api_key_failures(
             mock_resp.status_code = mock_response_status
             mock_requests_get = MagicMock(return_value=mock_resp)
 
-        with patch("agentic_doc.utils.requests.get", mock_requests_get):
+        with patch("agentic_doc.utils.requests.head", mock_requests_get):
             with pytest.raises(expected_exception) as exc_info:
                 check_endpoint_and_api_key("https://example123.com")
 


### PR DESCRIPTION
- This PR changes metadata "leaf types" from dict[str, list[str]] to a new MetadataType, which at the moment contains value (the field extraction value), experimental_confidence (an experimental version of confidence score for the field extraction result), and chunk_references (chunk ids from which the field extraction result was gathered)
- Also included a helpful utils function for getting specific chunks from chunk ids. 
- Updated GitHub workflow files so that pushes to main don't release new versions of the library, only pushes to the "release" branch

Some open questions:
- Should 'experimental_confidence' be called something else? Or, should we even consider the more complex approach of having a sort of "beta_parse" function or even a beta module (beta.parse)? Note that this would likely entail traversing the metadata and removing confidence from the original parse function.
- Should we add more utils functions? Or should this function be changed to take in a list of chunk ids and return a list of chunks? Or something else?

Note: As of the time I am making this PR, confidence and value aren't added in the API, so I'm keeping them as optional in the MetadataType definition. Eventually, they shouldn't be. 