### PR TITLE
Fix: Handle out-of-bounds bounding box coordinates during image cropping

### DIFF
--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -175,9 +175,27 @@ def _crop_image(image: np.ndarray, bbox: ChunkGroundingBox) -> np.ndarray:
 
     # Convert normalized coordinates to absolute coordinates
     height, width = image.shape[:2]
-    assert (
-        0 <= xmin_f <= 1 and 0 <= ymin_f <= 1 and 0 <= xmax_f <= 1 and 0 <= ymax_f <= 1
-    )
+
+    # Throw warning if coordinates are out of bounds
+    if (
+        xmin_f < 0
+        or ymin_f < 0
+        or xmax_f > 1
+        or ymax_f > 1
+        or xmin_f > xmax_f
+        or ymin_f > ymax_f
+    ):
+        _LOGGER.warning(
+            "Coordinates are out of bounds",
+            bbox=bbox,
+        )
+
+    # Clamp coordinates to valid range [0, 1]
+    xmin_f = max(0, min(1, xmin_f))
+    ymin_f = max(0, min(1, ymin_f))
+    xmax_f = max(0, min(1, xmax_f))
+    ymax_f = max(0, min(1, ymax_f))
+
     xmin = math.floor(xmin_f * width)
     xmax = math.ceil(xmax_f * width)
     ymin = math.floor(ymin_f * height)

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,9 @@ pytest tests/unit/test_parse_document.py
 
 # Run a specific test
 pytest tests/unit/test_parse_document.py::TestParseAndSaveDocument::test_parse_single_page_pdf
+
+# For integration test, you need VA API Key
+vision_agent_api_key=xxxx poetry run pytest tests/integ/test_parse_integ.py::test_parse_and_save_documents_multiple_inputs
 ```
 
 ## Adding New Tests

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -807,6 +807,67 @@ def test_crop_image_boundary_conditions():
     assert crop_small.shape[2] == 3
 
 
+def test_crop_image_coordinate_clamping():
+    # Test coordinate clamping for out-of-bounds coordinates
+    img = np.ones((100, 100, 3), dtype=np.uint8) * 255  # White image
+
+    # Test with negative coordinates - should be clamped to 0
+    bbox_negative = ChunkGroundingBox(l=-0.1, t=-0.2, r=0.5, b=0.5)
+    crop_negative = _crop_image(img, bbox_negative)
+    assert isinstance(crop_negative, np.ndarray)
+    assert crop_negative.shape[2] == 3
+    assert crop_negative.shape[0] > 0 and crop_negative.shape[1] > 0
+
+    # Test with coordinates > 1 - should be clamped to 1
+    bbox_over_one = ChunkGroundingBox(l=0.5, t=0.5, r=1.2, b=1.3)
+    crop_over_one = _crop_image(img, bbox_over_one)
+    assert isinstance(crop_over_one, np.ndarray)
+    assert crop_over_one.shape[2] == 3
+    assert crop_over_one.shape[0] > 0 and crop_over_one.shape[1] > 0
+
+    # Test with mixed invalid coordinates
+    bbox_mixed = ChunkGroundingBox(l=-0.5, t=0.2, r=1.5, b=0.8)
+    crop_mixed = _crop_image(img, bbox_mixed)
+    assert isinstance(crop_mixed, np.ndarray)
+    assert crop_mixed.shape[2] == 3
+    assert crop_mixed.shape[0] > 0 and crop_mixed.shape[1] > 0
+
+    # Test with all coordinates out of bounds (should still work)
+    bbox_all_invalid = ChunkGroundingBox(l=-1.0, t=-1.0, r=2.0, b=2.0)
+    crop_all_invalid = _crop_image(img, bbox_all_invalid)
+    assert isinstance(crop_all_invalid, np.ndarray)
+    assert crop_all_invalid.shape[2] == 3
+    # Should crop the entire image when clamped
+    assert crop_all_invalid.shape == (100, 100, 3)
+
+    # Test with extreme values that result in valid crops after clamping
+    bbox_extreme = ChunkGroundingBox(l=-999.0, t=-500.0, r=0.5, b=1000.0)
+    crop_extreme = _crop_image(img, bbox_extreme)
+    assert isinstance(crop_extreme, np.ndarray)
+    assert crop_extreme.shape[2] == 3
+    assert crop_extreme.shape[0] > 0 and crop_extreme.shape[1] > 0
+
+    # Test edge case where clamping results in zero-size crop (top == bottom)
+    bbox_zero_height = ChunkGroundingBox(
+        l=0.2, t=500.0, r=0.8, b=600.0
+    )  # Both t and b clamp to 1.0
+    crop_zero_height = _crop_image(img, bbox_zero_height)
+    assert isinstance(crop_zero_height, np.ndarray)
+    assert crop_zero_height.shape[2] == 3
+    # May have zero height when top == bottom after clamping
+    assert crop_zero_height.shape[0] >= 0 and crop_zero_height.shape[1] > 0
+
+    # Test edge case where clamping results in zero-size crop (left == right)
+    bbox_zero_width = ChunkGroundingBox(
+        l=500.0, t=0.2, r=600.0, b=0.8
+    )  # Both l and r clamp to 1.0
+    crop_zero_width = _crop_image(img, bbox_zero_width)
+    assert isinstance(crop_zero_width, np.ndarray)
+    assert crop_zero_width.shape[2] == 3
+    # May have zero width when left == right after clamping
+    assert crop_zero_width.shape[0] > 0 and crop_zero_width.shape[1] >= 0
+
+
 def test_save_groundings_as_images_with_empty_chunks(temp_dir):
     # Test saving groundings when there are no chunks
     img_path = temp_dir / "test.jpg"


### PR DESCRIPTION
## Problem
Document parsing failed when bounding box coordinates were slightly outside [0,1] range due to floating-point precision issues:


![image](https://github.com/user-attachments/assets/299f4e8b-d178-49e6-9e26-6c6701662880)



```
--- An unexpected error occurred during the main processing workflow --- (406541659.py:213)
Traceback (most recent call last):
  File "C:\Users\ZhiEnTan\AppData\Local\Temp\ipykernel_14360\406541659.py", line 189, in main
    parsed_files = parse_documents(documents=pdf_paths, grounding_save_dir=grounding_directory)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\agentic_doc\parse.py", line 287, in parse_documents
    return list(
           ^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\tqdm\std.py", line 1181, in __iter__
    for obj in iterable:
  File "c:\Users\ZhiEnTan\anaconda3\Lib\concurrent\futures\_base.py", line 619, in result_iterator
    yield _result_or_cancel(fs.pop())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\concurrent\futures\_base.py", line 317, in _result_or_cancel
    return fut.result(timeout)
           ^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\concurrent\futures\_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\concurrent\futures\_base.py", line 401, in __get_result
    raise self._exception
  File "c:\Users\ZhiEnTan\anaconda3\Lib\concurrent\futures\thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\agentic_doc\parse.py", line 244, in _parse_document_without_save
    result = parse_and_save_document(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\agentic_doc\parse.py", line 421, in parse_and_save_document
    save_groundings_as_images(
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\agentic_doc\utils.py", line 104, in save_groundings_as_images
    page_result = _crop_groundings(page_img, chunks, save_dir, inplace)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\agentic_doc\utils.py", line 144, in _crop_groundings
    cropped = _crop_image(img, grounding.box)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\ZhiEnTan\anaconda3\Lib\site-packages\agentic_doc\utils.py", line 175, in _crop_image
    0 <= xmin_f <= 1 and 0 <= ymin_f <= 1 and 0 <= xmax_f <= 1 and 0 <= ymax_f <= 1
```

## Fix
- **Replaced strict assertion** with coordinate clamping
- **Added warning logs** for out-of-bounds coordinates  
- **Clamp values to [0,1] range** automatically

```python
# Before: strict assertion (crashed)
assert 0 <= xmin_f <= 1 and 0 <= ymin_f <= 1 and 0 <= xmax_f <= 1 and 0 <= ymax_f <= 1

# After: graceful handling
if coordinates_out_of_bounds:
    _LOGGER.warning("Coordinates are out of bounds", bbox=bbox)

# Clamp to valid range
xmin_f = max(0, min(1, xmin_f))
xmax_f = max(0, min(1, xmax_f))
# ... etc
```


