### PR TITLE
chore: dont break publishing pipeline if version bump fails to commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,5 +124,4 @@ jobs:
           poetry version ${TAG#v}
           new_version=`poetry version`
           git add pyproject.toml
-          git commit -m "[skip ci] chore(release): ${new_version}"
-          git push -f
+          git commit -m "[skip ci] chore(release): ${new_version}" && git push -f || true


### PR DESCRIPTION
Although  pypi publication  succeeds, the publishing pipeline is marked as failed if the version in `pyproject.toml` in main is already set to the published version.

This PR fixes that by ignoring commit / push errors. The version in `pyproject.toml` is not that important too, as we generate the version number when building the GitHub release.