### PR TITLE
Add ability to filter by certain chunk types when saving groundings

### DIFF
--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -137,6 +137,7 @@ class ParsedDocument(BaseModel, Generic[T]):
     result_path: Optional[Path] = None
     errors: list[PageError] = Field(default_factory=list)
     extraction_error: Optional[str] = None
+    filename: Optional[str] = None
 
 
 class RetryableError(Exception):

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -30,12 +30,11 @@ from agentic_doc.config import Settings, get_settings, ParseConfig
 from agentic_doc.connectors import BaseConnector, ConnectorConfig, create_connector
 from agentic_doc.utils import (
     check_endpoint_and_api_key,
-    download_file,
     get_file_type,
-    is_valid_httpurl,
     log_retry_failure,
     save_groundings_as_images,
     split_pdf,
+    _doc_to_path
 )
 
 _LOGGER = structlog.getLogger(__name__)
@@ -415,17 +414,7 @@ def parse_and_save_document(
         Path | ParsedDocument: The file path to the saved result or the parsed document data.
     """
     with tempfile.TemporaryDirectory() as temp_dir:
-        if isinstance(document, str) and is_valid_httpurl(document):
-            document = Url(document)
-
-        if isinstance(document, Url):
-            output_file_path = Path(temp_dir) / Path(str(document)).name
-            download_file(document, str(output_file_path))
-            document = output_file_path
-        else:
-            document = Path(document)
-            if isinstance(document, Path) and not document.exists():
-                raise FileNotFoundError(f"File not found: {document}")
+        document = _doc_to_path(document, temp_dir)
 
         file_type = get_file_type(document)
 

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -34,7 +34,7 @@ from agentic_doc.utils import (
     log_retry_failure,
     save_groundings_as_images,
     split_pdf,
-    _doc_to_path
+    _doc_to_path,
 )
 
 _LOGGER = structlog.getLogger(__name__)

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -133,7 +133,7 @@ def parse(
     )
 
     # Convert results to ParsedDocument objects
-    return _convert_to_parsed_documents(parse_results, result_save_dir)
+    return _convert_to_parsed_documents(parse_results, result_save_dir, doc_paths)
 
 
 def _get_document_paths(
@@ -200,12 +200,14 @@ def _get_documents_from_bytes(doc_bytes: bytes) -> List[Path]:
 def _convert_to_parsed_documents(
     parse_results: Union[List[ParsedDocument[T]], List[Path]],
     result_save_dir: Optional[Union[str, Path]],
+    doc_paths: Sequence[Union[str, Path, Url]],
 ) -> List[ParsedDocument[T]]:
     """Convert parse results to ParsedDocument objects."""
     parsed_docs = []
 
-    for result in parse_results:
+    for i, result in enumerate(parse_results):
         if isinstance(result, ParsedDocument):
+            result.filename = str(doc_paths[i])
             parsed_docs.append(result)
         elif isinstance(result, Path):
             with open(result, encoding="utf-8") as f:
@@ -213,6 +215,7 @@ def _convert_to_parsed_documents(
             parsed_doc: ParsedDocument[T] = ParsedDocument.model_validate(data)
             if result_save_dir:
                 parsed_doc.result_path = result
+            parsed_doc.filename = str(doc_paths[i])
             parsed_docs.append(parsed_doc)
         else:
             raise ValueError(f"Unexpected result type: {type(result)}")

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -238,7 +238,7 @@ def _doc_to_path(document: Union[str, Path, Url], temp_storage_dir: str) -> Path
 
 
 def split_pdf(
-    input_pdf_path: Union[str, Path],
+    input_pdf_path: Union[str, Path, Url],
     output_dir: Union[str, Path],
     split_size: int = 10,
 ) -> list[Document]:
@@ -250,7 +250,7 @@ def split_pdf(
         output_dir (str | Path): Directory where mini PDF files will be saved.
         split_size (int): Maximum number of pages per mini PDF file (default is 10).
     """
-    input_pdf_path = Path(input_pdf_path)
+    input_pdf_path = _doc_to_path(input_pdf_path)
     assert input_pdf_path.exists(), f"Input PDF file not found: {input_pdf_path}"
     assert (
         0 < split_size <= 100
@@ -318,17 +318,17 @@ def log_retry_failure(retry_state: RetryCallState) -> None:
 
 
 def viz_parsed_document(
-    file_path: Union[str, Path],
+    file_path: Union[str, Path, Url],
     parsed_document: ParsedDocument,
     *,
-    output_dir: Union[str, Path, None] = None,
+    output_dir: Optional[Union[str, Path]] = None,
     viz_config: Union[VisualizationConfig, None] = None,
 ) -> list[Image.Image]:
     if viz_config is None:
         viz_config = VisualizationConfig()
 
     viz_result_np: list[np.ndarray] = []
-    file_path = Path(file_path)
+    file_path = _doc_to_path(file_path)
     file_type = get_file_type(file_path)
     _LOGGER.info(f"Visualizing parsed document of: '{file_path}'")
     if file_type == "image":
@@ -362,7 +362,7 @@ def viz_parsed_document(
 def viz_chunks(
     img: np.ndarray,
     chunks: list[Chunk],
-    viz_config: Union[VisualizationConfig, None] = None,
+    viz_config: Optional[VisualizationConfig] = None,
 ) -> np.ndarray:
     if viz_config is None:
         viz_config = VisualizationConfig()

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -471,7 +471,7 @@ def download_file(file_url: Url, output_filepath: str) -> None:
     with httpx.stream("GET", str(file_url), timeout=None) as response:
         if response.status_code != 200:
             raise Exception(
-                f"Download failed for '{file_url}'. Status code: {response.status_code} {response.text}"
+                f"Download failed for '{file_url}'. Status code: {response.status_code}"
             )
 
         with open(output_filepath, "wb") as f:

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -358,7 +358,9 @@ def viz_parsed_document(
             output_dir.mkdir(parents=True, exist_ok=True)
             for i, viz_np in enumerate(viz_result_np):
                 viz_np = cv2.cvtColor(viz_np, cv2.COLOR_RGB2BGR)
-                cv2.imwrite(str(output_dir / f"{file_path.stem}_viz_page_{i}.png"), viz_np)
+                cv2.imwrite(
+                    str(output_dir / f"{file_path.stem}_viz_page_{i}.png"), viz_np
+                )
 
     return [Image.fromarray(viz_np) for viz_np in viz_result_np]
 

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -353,12 +353,12 @@ def viz_parsed_document(
                     viz_np = viz_chunks(img, chunks, viz_config)
                     viz_result_np.append(viz_np)
 
-    if output_dir:
-        output_dir = Path(output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        for i, viz_np in enumerate(viz_result_np):
-            viz_np = cv2.cvtColor(viz_np, cv2.COLOR_RGB2BGR)
-            cv2.imwrite(str(output_dir / f"{file_path.stem}_viz_page_{i}.png"), viz_np)
+        if output_dir:
+            output_dir = Path(output_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            for i, viz_np in enumerate(viz_result_np):
+                viz_np = cv2.cvtColor(viz_np, cv2.COLOR_RGB2BGR)
+                cv2.imwrite(str(output_dir / f"{file_path.stem}_viz_page_{i}.png"), viz_np)
 
     return [Image.fromarray(viz_np) for viz_np in viz_result_np]
 

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -362,7 +362,7 @@ def viz_parsed_document(
                     str(output_dir / f"{file_path.stem}_viz_page_{i}.png"), viz_np
                 )
 
-    return [Image.fromarray(viz_np) for viz_np in viz_result_np]
+        return [Image.fromarray(viz_np) for viz_np in viz_result_np]
 
 
 def viz_chunks(

--- a/agentic_doc/utils.py
+++ b/agentic_doc/utils.py
@@ -66,7 +66,7 @@ def save_groundings_as_images(
     chunks: list[Chunk],
     save_dir: Union[str, Path],
     inplace: bool = True,
-    filter_by: list[str] = None
+    filter_by: Optional[list[str]] = None,
 ) -> dict[str, list[Path]]:
     """
     Save the chunks as images based on the bounding box in each chunk.
@@ -76,7 +76,7 @@ def save_groundings_as_images(
         chunks (list[Chunk]): The chunks to save or update.
         save_dir (Path | str): The directory to save the images of the chunks.
         inplace (bool): Whether to update the input chunks in place.
-        filter_by (list[str]): List of chunk types to filter by. If provided, only chunks of the given types will be saved.
+        filter_by (list[str] | None): List of chunk types to filter by. If provided, only chunks of the given types will be saved. (optional)
 
     Returns:
         dict[str, Path]: The dictionary of saved image paths. The key is the chunk id and the value is the path to the saved image.
@@ -94,7 +94,9 @@ def save_groundings_as_images(
         save_dir.mkdir(parents=True, exist_ok=True)
         if filter_by:
             filter_by = [filter.lower() for filter in filter_by]
-            chunks = [chunk for chunk in chunks if chunk.chunk_type.lower() in filter_by]
+            chunks = [
+                chunk for chunk in chunks if chunk.chunk_type.lower() in filter_by
+            ]
         if file_type == "image":
             img = cv2.imread(str(file_path))
             return _crop_groundings(img, chunks, save_dir, inplace)
@@ -231,9 +233,9 @@ def _doc_to_path(document: Union[str, Path, Url], temp_storage_dir: str) -> Path
         document = Path(document)
         if isinstance(document, Path) and not document.exists():
             raise FileNotFoundError(f"File not found: {document}")
-        
+
     return document
-        
+
 
 def split_pdf(
     input_pdf_path: Union[str, Path],

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -163,7 +163,7 @@ def test_parse_and_save_document_with_local_file(temp_dir, mock_parsed_document)
 def test_parse_and_save_document_with_url(temp_dir, mock_parsed_document):
     # Mock download_file and _parse_pdf functions
     with (
-        patch("agentic_doc.parse.download_file") as mock_download,
+        patch("agentic_doc.utils.download_file") as mock_download,
         patch("agentic_doc.parse.get_file_type", return_value="pdf"),
         patch("agentic_doc.parse._parse_pdf", return_value=mock_parsed_document),
     ):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -340,6 +340,9 @@ def test_viz_parsed_document_pdf(temp_dir, mock_multi_page_parsed_document):
 
         pdf_path = temp_dir / "test.pdf"
         output_dir = temp_dir / "viz_output"
+        
+        with open(pdf_path, "wb") as f:
+            f.write(b"%PDF-1.7\n")
 
         # Test visualization with saving
         images = viz_parsed_document(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -686,8 +686,17 @@ def test_save_groundings_with_filter_by(temp_dir):
         assert "22222" in result
         assert "33333" not in result
 
-        # Check that write_bytes was called for only the figure chunk
         assert mock_write.call_count == 1
+
+        result = save_groundings_as_images(pdf_path, chunks, save_dir, filter_by=[ChunkType.figure])
+
+        # Check that the result contains the chunk_ids
+        assert "11111" not in result
+        assert "22222" in result
+        assert "33333" not in result
+
+        # Check that write_bytes was called for only the figure chunk (twice since we ran called the function twice)
+        assert mock_write.call_count == 2
 
 
 def test_read_img_rgb():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -614,6 +614,82 @@ def test_save_groundings_as_images_pdf(temp_dir):
         assert mock_write.call_count == 3
 
 
+def test_save_groundings_with_filter_by(temp_dir):
+    # Create a dummy PDF file
+    pdf_path = temp_dir / "test.pdf"
+    with open(pdf_path, "wb") as f:
+        f.write(b"%PDF-1.7\n")
+
+    # Create a directory to save the groundings
+    save_dir = temp_dir / "groundings"
+
+    # Create custom chunks with different page indices
+    chunks = [
+        Chunk(
+            text="Title",
+            chunk_type=ChunkType.text,
+            chunk_id="11111",
+            grounding=[
+                ChunkGrounding(
+                    page=0, box=ChunkGroundingBox(l=0.1, t=0.1, r=0.9, b=0.2)
+                )
+            ],
+        ),
+        Chunk(
+            text="Page content",
+            chunk_type=ChunkType.figure,
+            chunk_id="22222",
+            grounding=[
+                ChunkGrounding(
+                    page=0, box=ChunkGroundingBox(l=0.1, t=0.3, r=0.9, b=0.4)
+                )
+            ],
+        ),
+        Chunk(
+            text="Header",
+            chunk_type=ChunkType.text,
+            chunk_id="33333",
+            grounding=[
+                ChunkGrounding(
+                    page=1, box=ChunkGroundingBox(l=0.1, t=0.1, r=0.9, b=0.2)
+                )
+            ],
+        ),
+    ]
+
+    # Mock the required functions to avoid filesystem operations
+    mock_buffer = MagicMock()
+    mock_buffer.tobytes.return_value = b"mock_png_data"
+
+    with patch("agentic_doc.utils.get_file_type", return_value="pdf"), patch(
+        "agentic_doc.utils.pymupdf.open"
+    ) as mock_pymupdf_open, patch(
+        "agentic_doc.utils.page_to_image",
+        return_value=np.zeros((100, 100, 3), dtype=np.uint8),
+    ), patch(
+        "cv2.imencode", return_value=(True, mock_buffer)
+    ), patch(
+        "pathlib.Path.write_bytes"
+    ) as mock_write, patch(
+        "pathlib.Path.mkdir", return_value=None
+    ):
+
+        # Mock the context manager returned by pymupdf.open
+        mock_pdf_doc = MagicMock()
+        mock_pymupdf_open.return_value.__enter__.return_value = mock_pdf_doc
+
+        # Call the function
+        result = save_groundings_as_images(pdf_path, chunks, save_dir, filter_by=['figure'])
+
+        # Check that the result contains the chunk_ids
+        assert "11111" not in result
+        assert "22222" in result
+        assert "33333" not in result
+
+        # Check that write_bytes was called for only the figure chunk
+        assert mock_write.call_count == 1
+
+
 def test_read_img_rgb():
     # Create a mock for cv2.imread and cv2.cvtColor
     with patch(


### PR DESCRIPTION
- Some code refactoring to avoid repetition
- Allow for remote URLs when saving groundings
- Save figures in correct colorspace
- Adds the ability to filter by certain chunk types when saving groundings, and adds a test that checks for this
- Adds filename to ParsedDocument class