### PR TITLE
chore: reduce number of retries for failed requests

### DIFF
--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -102,7 +102,7 @@ class Settings(BaseSettings):
         ge=1,
     )
     max_retries: int = Field(
-        default=100,
+        default=3,
         description="Maximum number of retries for a failed request",
         ge=0,
     )


### PR DESCRIPTION
We need to re-evaluate our failed requests retry strategy, but the current default max_retry is definitely way too high.

Temporarily reducing the number, so we don't ship this huge max_retries in the next versions.