### PR TITLE
feat: add rotation detection parameter

### DIFF
--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -134,7 +134,7 @@ class DocumentMetadata(BaseModel):
     processing_time_ms: Optional[int] = None
     pages_processed: Optional[int] = None
     user_id: Optional[str] = None
-    pages_rotation_angles: Optional[dict[str, float]]
+    pages_rotation_angles: Optional[dict[str, float]] = Field(default_factory=dict)
 
 
 class ParsedDocument(BaseModel, Generic[T]):

--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -134,7 +134,9 @@ class DocumentMetadata(BaseModel):
     processing_time_ms: Optional[int] = None
     pages_processed: Optional[int] = None
     user_id: Optional[str] = None
-    pages_rotation_angles: Optional[dict[str, float]] = Field(default_factory=dict)
+    pages_rotation_angles: Optional[dict[str, float]] = Field(
+        default_factory=dict,  # type: ignore[arg-type]
+    )
 
 
 class ParsedDocument(BaseModel, Generic[T]):

--- a/agentic_doc/common.py
+++ b/agentic_doc/common.py
@@ -134,6 +134,7 @@ class DocumentMetadata(BaseModel):
     processing_time_ms: Optional[int] = None
     pages_processed: Optional[int] = None
     user_id: Optional[str] = None
+    pages_rotation_angles: Optional[dict[str, float]]
 
 
 class ParsedDocument(BaseModel, Generic[T]):

--- a/agentic_doc/config.py
+++ b/agentic_doc/config.py
@@ -33,6 +33,7 @@ class ParseConfig:
         extraction_schema: Optional[dict[str, Any]] = None,
         split_size: Optional[int] = None,
         extraction_split_size: Optional[int] = None,
+        enable_rotation_detection: Optional[bool] = None,
     ) -> None:
         self.api_key = api_key
         self.include_marginalia = include_marginalia
@@ -41,6 +42,7 @@ class ParseConfig:
         self.extraction_schema = extraction_schema
         self.split_size = split_size
         self.extraction_split_size = extraction_split_size
+        self.enable_rotation_detection = enable_rotation_detection
 
 
 class SettingsOverrides:

--- a/agentic_doc/parse.py
+++ b/agentic_doc/parse.py
@@ -781,6 +781,8 @@ def _send_parsing_request(
                 "include_marginalia": include_marginalia,
                 "include_metadata_in_markdown": include_metadata_in_markdown,
             }
+            if config and config.enable_rotation_detection is not None:
+                data["enable_rotation_detection"] = config.enable_rotation_detection
 
             def resolve_refs(obj: Any, defs: Dict[str, Any]) -> Any:
                 if isinstance(obj, dict):

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -578,14 +578,6 @@ def test_send_parsing_dont_send_none_parameters():
 
 
 def test_send_parsing_send_false_parameters():
-    """
-    When sending the requests, "None" ParseConfig params should be
-    treated as "not set in the request", instead of sending "None" or
-    any other default value.
-
-    This should allow us to better control default values from the
-    backend, with client side not overriding it every time.
-    """
     # Create a mock response
     mock_response = MagicMock()
     mock_response.status_code = 200

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -541,22 +541,22 @@ def test_send_parsing_dont_send_none_parameters():
 
     # Mock httpx.post to return the mock response
     with (
+        patch("agentic_doc.parse.httpx.post", return_value=mock_response) as mock_post,
         patch("agentic_doc.parse.open", MagicMock()),
         patch("agentic_doc.parse.Path") as mock_path,
     ):
-        with patch("agentic_doc.parse.httpx.post", return_value=mock_response) as mock_post:
-            # Setup mock to make the suffix check work
-            mock_path_instance = MagicMock()
-            mock_path_instance.suffix.lower.return_value = ".pdf"
-            mock_path.return_value = mock_path_instance
+        # Setup mock to make the suffix check work
+        mock_path_instance = MagicMock()
+        mock_path_instance.suffix.lower.return_value = ".pdf"
+        mock_path.return_value = mock_path_instance
 
-            # Call the function
-            result = _send_parsing_request(
-                "test.pdf",
-                config=ParseConfig(
-                    enable_rotation_detection=None,
-                ),
-            )
+        # Call the function
+        result = _send_parsing_request(
+            "test.pdf",
+            config=ParseConfig(
+                enable_rotation_detection=None,
+            ),
+        )
 
         # Check that the result matches the mock response
         assert result == {"data": {"markdown": "Test", "chunks": []}}
@@ -569,8 +569,8 @@ def test_send_parsing_dont_send_none_parameters():
                     "include_metadata_in_markdown": True,
                 },
                 headers={
-                    "Authorization": "Basic 12333",
-                    "runtime_tag": "agentic-doc-v0.3.1"
+                    "Authorization": ANY,
+                    "runtime_tag": ANY
                 },
                 timeout=None
             )
@@ -585,22 +585,22 @@ def test_send_parsing_send_false_parameters():
 
     # Mock httpx.post to return the mock response
     with (
+        patch("agentic_doc.parse.httpx.post", return_value=mock_response) as mock_post,
         patch("agentic_doc.parse.open", MagicMock()),
         patch("agentic_doc.parse.Path") as mock_path,
     ):
-        with patch("agentic_doc.parse.httpx.post", return_value=mock_response) as mock_post:
-            # Setup mock to make the suffix check work
-            mock_path_instance = MagicMock()
-            mock_path_instance.suffix.lower.return_value = ".pdf"
-            mock_path.return_value = mock_path_instance
+        # Setup mock to make the suffix check work
+        mock_path_instance = MagicMock()
+        mock_path_instance.suffix.lower.return_value = ".pdf"
+        mock_path.return_value = mock_path_instance
 
-            # Call the function
-            result = _send_parsing_request(
-                "test.pdf",
-                config=ParseConfig(
-                    enable_rotation_detection=False,
-                ),
-            )
+        # Call the function
+        result = _send_parsing_request(
+            "test.pdf",
+            config=ParseConfig(
+                enable_rotation_detection=False,
+            ),
+        )
 
         # Check that the result matches the mock response
         assert result == {"data": {"markdown": "Test", "chunks": []}}
@@ -614,8 +614,8 @@ def test_send_parsing_send_false_parameters():
                     "enable_rotation_detection": False,
                 },
                 headers={
-                    "Authorization": "Basic 12333",
-                    "runtime_tag": "agentic-doc-v0.3.1"
+                    "Authorization": ANY,
+                    "runtime_tag": ANY
                 },
                 timeout=None
             )


### PR DESCRIPTION
Add to `ParseConfig` the `enable_rotation_detection: bool` parameter, to automatically detect if document pages are rotated or not.

This also adds to the response `metadata` which pages were actually detected as rotate, and which rotation was detected.