### PR TITLE
feat: ade update — self-update command, periodic update nudge, unknown-model hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ billed parse/extract results.
 (Developing or installing from source? See
 [CONTRIBUTING.md](CONTRIBUTING.md).)
 
+Staying current is one command: `ade update` checks the release channel
+and, for a binary install, replaces the app in place after verifying the
+release checksum (`--yes` skips the confirmation). A `uv`/`pipx` install
+is never touched — `update` points at `uv tool upgrade ade-cli` instead;
+`ade version` reports which kind you have. The CLI also checks quietly
+in the background at most once a day and mentions a newer release on
+stderr; set `ADE_NO_UPDATE_CHECK=1` to turn that off.
+
 ## Auth
 
 | command | what it does |

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -297,7 +297,7 @@
     {
       "name": "version",
       "usage": "ade version [--json]",
-      "summary": "Print the ade version.",
+      "summary": "Print the ade version and install mode: 'binary' (the standalone\napp \u2014 `ade update` replaces it in place) or 'python' (uv/pipx \u2014\nupgrade with `uv tool upgrade ade-cli`).",
       "arguments": [],
       "flags": [],
       "supports_json": true,
@@ -307,6 +307,48 @@
           {
             "key": "version",
             "what": "the installed ade version"
+          },
+          {
+            "key": "install",
+            "what": "how it is installed: binary (standalone app, self-updates via `ade update`) | python (uv/pipx \u2014 upgrade with `uv tool upgrade ade-cli`)"
+          }
+        ]
+      },
+      "band": "credentials & CLI lifecycle"
+    },
+    {
+      "name": "update",
+      "usage": "ade update [options] [--json]",
+      "summary": "Check the release channel for a newer CLI and self-update on\nconfirmation. A standalone-binary install (see `ade version`)\nreplaces itself in place after verifying the release checksum; a\nuv/pipx install is never mutated \u2014 the command reports the newer\nversion and points at `uv tool upgrade ade-cli`.",
+      "arguments": [],
+      "flags": [
+        {
+          "flags": "--yes",
+          "metavar": null,
+          "required": false,
+          "default": null,
+          "help": "Install without the interactive confirmation (required when stdin is not a terminal)."
+        }
+      ],
+      "supports_json": true,
+      "result": {
+        "shape": "object",
+        "keys": [
+          {
+            "key": "current",
+            "what": "the running version"
+          },
+          {
+            "key": "latest",
+            "what": "the latest released version (null when the release channel is not visible)"
+          },
+          {
+            "key": "updated",
+            "what": "true when this run installed the newer version"
+          },
+          {
+            "key": "install",
+            "what": "binary | python \u2014 python installs are never mutated, only pointed at `uv tool upgrade ade-cli`"
           }
         ]
       },

--- a/src/ade_cli/guarantee.py
+++ b/src/ade_cli/guarantee.py
@@ -29,6 +29,7 @@ from typing import Callable, Iterator, NoReturn
 import httpx
 import typer
 
+from . import update
 from .config import DEFAULT_ENVIRONMENT
 from .gateway import GatewayError
 from .oauth import ReloginRequired
@@ -484,6 +485,11 @@ class Guarantee:
         # named, never a bare status line.
         label = f"{error.code}: " if error.code else ""
         human = f"HTTP {error.status_code}: {label}{error.detail}"
+        # A registry-style "unknown model" rejection usually means the API
+        # moved past this CLI build (#138) — say so, in both renderings.
+        hint = update.unknown_model_hint(error.detail)
+        if hint:
+            human = f"{human} {hint}"
         if error.status_code == 401 and not isinstance(error, ReloginRequired):
             # One canonical line for every rejected credential (#117): the
             # platform's 401 bodies vary by which check rejected the key
@@ -508,6 +514,7 @@ class Guarantee:
                 "status_code": error.status_code,
                 "code": error.code,
                 "message": error.detail,
+                **({"hint": hint} if hint else {}),
                 **self.context,
             },
             human,

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -52,6 +52,7 @@ BANDS: list[tuple[str, list[str]]] = [
             "login",
             "logout",
             "version",
+            "update",
             "help",
         ],
     ),
@@ -312,7 +313,23 @@ RESULTS: dict[str, dict] = {
     },
     "version": {
         "shape": "object",
-        "keys": [("version", "the installed ade version")],
+        "keys": [
+            ("version", "the installed ade version"),
+            ("install", "how it is installed: binary (standalone app, "
+             "self-updates via `ade update`) | python (uv/pipx — upgrade "
+             "with `uv tool upgrade ade-cli`)"),
+        ],
+    },
+    "update": {
+        "shape": "object",
+        "keys": [
+            ("current", "the running version"),
+            ("latest", "the latest released version (null when the release "
+             "channel is not visible)"),
+            ("updated", "true when this run installed the newer version"),
+            ("install", "binary | python — python installs are never "
+             "mutated, only pointed at `uv tool upgrade ade-cli`"),
+        ],
     },
     "help": {
         "shape": "object",

--- a/src/ade_cli/main.py
+++ b/src/ade_cli/main.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from importlib.metadata import version as _installed_version
-
 import typer
 
 from .auth import auth_app, login, logout
@@ -16,6 +14,7 @@ from .output import JSON_FLAG, emit, set_id_only
 from .parse import parse
 from .ports import Ports
 from .telemetry import LedgerGroup
+from .update import current_version, install_mode, update
 from .view import view
 
 app = typer.Typer(
@@ -56,6 +55,7 @@ app.command()(extract)
 app.command()(find)
 app.command()(view)
 app.command()(crop)
+app.command()(update)
 app.command("help")(help_command)
 
 
@@ -71,6 +71,14 @@ def _root(ctx: typer.Context) -> None:
 
 @app.command()
 def version(as_json: bool = JSON_FLAG) -> None:
-    """Print the ade version."""
-    v = _installed_version("ade-cli")
-    emit({"version": v}, f"ade {v}", as_json=as_json)
+    """Print the ade version and install mode: 'binary' (the standalone
+    app — `ade update` replaces it in place) or 'python' (uv/pipx —
+    upgrade with `uv tool upgrade ade-cli`)."""
+    v = current_version()
+    mode = install_mode()
+    label = "standalone binary" if mode == "binary" else "python environment"
+    emit(
+        {"version": v, "install": mode},
+        f"ade {v} ({label})",
+        as_json=as_json,
+    )

--- a/src/ade_cli/telemetry.py
+++ b/src/ade_cli/telemetry.py
@@ -278,6 +278,9 @@ class LedgerGroup(TyperGroup):
             # command's output and exit path are already decided, and is
             # as silent as the append above.
             _ship_after_command(self, argv, kwargs.get("obj"))
+            # Then the throttled update check (#138): same posture — after
+            # the real work, never surfaces, never raises.
+            _update_check_after_command(self, argv, kwargs.get("obj"))
 
 
 def _ship_after_command(root: object, argv: list[str], ports: object) -> None:
@@ -300,8 +303,40 @@ def _ship_after_command(root: object, argv: list[str], ports: object) -> None:
         pass
 
 
+def _update_check_after_command(root: object, argv: list[str], ports: object) -> None:
+    """Hand the post-command update check to update.py (#138): the
+    injected transport and terminal-ness when the invocation carried
+    Ports (the test seam), the real ones otherwise. Never surfaces,
+    never raises — same posture as the flush above."""
+    try:
+        from . import update
+
+        transport = getattr(ports, "transport", None)
+        if transport is None:
+            import httpx
+
+            transport = httpx.HTTPTransport()
+        stderr_is_tty = getattr(ports, "stderr_is_tty", _stderr_is_tty)()
+        command, _ = classify_argv(root, argv)
+        update.after_command(
+            command=command,
+            env=os.environ,
+            transport=transport,
+            stderr_is_tty=stderr_is_tty,
+        )
+    except BaseException:
+        pass
+
+
 def _stdout_is_tty() -> bool:
     try:
         return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def _stderr_is_tty() -> bool:
+    try:
+        return sys.stderr.isatty()
     except Exception:
         return False

--- a/src/ade_cli/update.py
+++ b/src/ade_cli/update.py
@@ -37,6 +37,7 @@ import sys
 import tarfile
 import time
 import zipfile
+from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _installed_version
 from pathlib import Path
@@ -46,6 +47,7 @@ import httpx
 import typer
 
 from .config import load_config
+from .filelock import exclusive
 from .output import EXIT_FAILED, EXIT_USAGE, JSON_FLAG, emit, exit_with
 from .ports import Ports
 
@@ -62,6 +64,7 @@ CHECK_TIMEOUT_SECONDS = 10.0
 NUDGE_TIMEOUT_SECONDS = 3.0
 CHECK_INTERVAL_SECONDS = 24 * 3600.0
 CACHE_NAME = "update-check.json"
+CACHE_LOCK_NAME = ".update-check.lock"
 
 
 class UpdateCheckError(Exception):
@@ -112,19 +115,34 @@ def is_newer(candidate: str | None, current: str) -> bool:
     return new > old
 
 
+@dataclass(frozen=True)
+class Release:
+    """What the version check learned: the latest version, plus the
+    release's asset ids — the handle the authenticated download path
+    needs while the repo is private (install.sh's fetch_api)."""
+
+    version: str
+    assets: dict[str, int]  # asset name -> asset id
+
+
+def _ambient_token() -> str | None:
+    """An ambient GITHUB_TOKEN/GH_TOKEN — used when present, never
+    stored (install.sh's posture). Lifts the anonymous API rate limit
+    and covers the private-repo window."""
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
 def fetch_latest(
     transport: httpx.BaseTransport, *, timeout: float
-) -> str | None:
-    """The latest release's version (tag without the ``v``), or None when
-    the channel is unavailable in the way that means "skip silently":
-    404/403 is what the unauthenticated API answers while the repo is
-    private (or has no release yet), and 403 is also its anonymous
-    rate-limit answer. An ambient GITHUB_TOKEN/GH_TOKEN rides along when
-    present — the same posture as install.sh, never stored. Anything
-    else — network failure, an unexpected status, a malformed body —
-    raises UpdateCheckError."""
+) -> Release | None:
+    """The latest release (version without the ``v``, plus asset ids), or
+    None when the channel is unavailable in the way that means "skip
+    silently": 404/403 is what the unauthenticated API answers while the
+    repo is private (or has no release yet), and 403 is also its
+    anonymous rate-limit answer. Anything else — network failure, an
+    unexpected status, a malformed body — raises UpdateCheckError."""
     headers = {"Accept": "application/vnd.github+json"}
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = _ambient_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
@@ -143,12 +161,22 @@ def fetch_latest(
             f"release channel answered HTTP {response.status_code}"
         )
     try:
-        tag = response.json().get("tag_name")
+        body = response.json()
     except json.JSONDecodeError:
-        tag = None
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    tag = body.get("tag_name")
     if not isinstance(tag, str) or not tag:
         raise UpdateCheckError("release channel sent no tag_name")
-    return tag.lstrip("v")
+    assets = {
+        entry["name"]: entry["id"]
+        for entry in (body.get("assets") or [])
+        if isinstance(entry, dict)
+        and isinstance(entry.get("name"), str)
+        and isinstance(entry.get("id"), int)
+    }
+    return Release(version=tag.lstrip("v"), assets=assets)
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +240,7 @@ def update(
     )
     progress.update(label="checking the release channel")
     try:
-        latest = fetch_latest(ports.transport, timeout=CHECK_TIMEOUT_SECONDS)
+        release = fetch_latest(ports.transport, timeout=CHECK_TIMEOUT_SECONDS)
     except UpdateCheckError as error:
         progress.close()
         exit_with(
@@ -222,6 +250,7 @@ def update(
             code=EXIT_FAILED,
         )
     progress.close()
+    latest = release.version if release else None
     # The explicit check counts against the periodic throttle too — a
     # fresh `update` should buy a quiet day, whatever it concluded.
     _write_cache(_home(os.environ), latest=latest)
@@ -265,7 +294,8 @@ def update(
         if not typer.confirm(f"Update ade {current} -> {latest}?"):
             emit(payload, "Update declined; nothing changed.", as_json=as_json)
             return
-    _self_replace(ports.transport, latest=latest, as_json=as_json, progress=progress)
+    assert release is not None  # is_newer(None, …) is False
+    _self_replace(ports.transport, release=release, as_json=as_json, progress=progress)
     emit(
         {**payload, "updated": True},
         f"Updated ade {current} -> {latest} in {install_root()} — takes "
@@ -274,8 +304,27 @@ def update(
     )
 
 
+def _asset_request(release: Release, name: str) -> tuple[str, dict]:
+    """(url, headers) for one release asset: the public versionless
+    latest/download URL normally; with an ambient token and a known
+    asset id, GitHub's authenticated release-assets endpoint instead —
+    the one download path that works while the repo is private
+    (install.sh's fetch_api)."""
+    token = _ambient_token()
+    asset_id = release.assets.get(name)
+    if token and asset_id is not None:
+        return (
+            f"https://api.github.com/repos/{REPO}/releases/assets/{asset_id}",
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/octet-stream",
+            },
+        )
+    return f"{DOWNLOAD_BASE_URL}/{name}", {}
+
+
 def _self_replace(
-    transport: httpx.BaseTransport, *, latest: str, as_json: bool, progress
+    transport: httpx.BaseTransport, *, release: Release, as_json: bool, progress
 ) -> None:
     """Download, verify, and swap in the latest frozen app. Mirrors
     install.sh: stage *inside* the install dir so the final steps are
@@ -315,18 +364,24 @@ def _self_replace(
         with httpx.Client(
             transport=transport, timeout=CHECK_TIMEOUT_SECONDS, follow_redirects=True
         ) as client:
-            _download(
+            url, headers = _asset_request(release, asset)
+            # The digest comes out of the download stream itself — the
+            # ~100 MB archive is never re-read (or held) in memory.
+            actual = _download(
                 client,
-                f"{DOWNLOAD_BASE_URL}/{asset}",
+                url,
+                headers,
                 archive,
                 progress=progress,
                 label=f"downloading {asset}",
                 fail=fail,
             )
             sums = staging / "SHA256SUMS.txt"
+            url, headers = _asset_request(release, "SHA256SUMS.txt")
             _download(
                 client,
-                f"{DOWNLOAD_BASE_URL}/SHA256SUMS.txt",
+                url,
+                headers,
                 sums,
                 progress=progress,
                 label="downloading SHA256SUMS.txt",
@@ -340,7 +395,6 @@ def _self_replace(
                 f"SHA256SUMS.txt on the release has no entry for {asset}; "
                 "not installing an unverifiable download.",
             )
-        actual = hashlib.sha256(archive.read_bytes()).hexdigest()
         if actual != expected:
             fail(
                 {
@@ -354,7 +408,16 @@ def _self_replace(
             )
         progress.update(label="installing")
         new_dir = staging / "new"
-        _extract_archive(archive, new_dir)
+        try:
+            _extract_archive(archive, new_dir)
+        except (tarfile.TarError, zipfile.BadZipFile, OSError) as error:
+            # Correctly checksummed but malformed still exits structured,
+            # never a traceback over a half-drawn progress line.
+            fail(
+                {"error": "bad_release_archive", "asset": asset, "message": str(error)},
+                f"The release archive {asset} cannot be unpacked ({error}); "
+                "not installing it.",
+            )
         # The archive holds a onedir app: ade/<binary> + ade/_internal/.
         binary_name = Path(sys.executable).name
         new_app = new_dir / "ade"
@@ -365,22 +428,31 @@ def _self_replace(
                 "app layout; not installing it.",
             )
         _swap(root, new_app, binary_name)
-        progress.update(label=f"updated to {latest}")
+        progress.update(label=f"updated to {release.version}")
         progress.close()
     finally:
         shutil.rmtree(staging, ignore_errors=True)
 
 
 def _download(
-    client: httpx.Client, url: str, dest: Path, *, progress, label: str, fail
-) -> None:
-    """Stream ``url`` to ``dest``, reporting received/total on the
-    progress line per chunk (tty rewrites in place; plain mode dedups to
-    one line per 10%). A body without Content-Length still shows the
-    moving label, just without a percentage."""
+    client: httpx.Client,
+    url: str,
+    headers: dict,
+    dest: Path,
+    *,
+    progress,
+    label: str,
+    fail,
+) -> str:
+    """Stream ``url`` to ``dest`` and return the body's sha256 hexdigest,
+    reporting received/total on the progress line per chunk (tty rewrites
+    in place; plain mode dedups to one line per 10%). A body without
+    Content-Length still shows the moving label, just without a
+    percentage."""
     progress.update(label=label)
+    digest = hashlib.sha256()
     try:
-        with client.stream("GET", url) as response:
+        with client.stream("GET", url, headers=headers) as response:
             if response.status_code != 200:
                 fail(
                     {
@@ -398,6 +470,7 @@ def _download(
             with dest.open("wb") as out:
                 for chunk in response.iter_bytes():
                     out.write(chunk)
+                    digest.update(chunk)
                     received += len(chunk)
                     if total:
                         progress.update(label=label, fraction=received / total)
@@ -406,6 +479,7 @@ def _download(
             {"error": "update_download_failed", "url": url, "message": str(error)},
             f"Download failed for {url}: {error}.",
         )
+    return digest.hexdigest()
 
 
 def _expected_sum(sums_text: str, asset: str) -> str | None:
@@ -436,7 +510,14 @@ def _swap(root: Path, new_app: Path, binary_name: str) -> None:
     running ``.exe`` or its mapped DLLs, but it *can* rename them — then
     the new pieces move in. The aside-renamed leftovers are swept right
     away where the OS allows and by a later run's sweep where it does
-    not."""
+    not.
+
+    Same posture as install.sh, deliberately: a concurrently *launched*
+    ade can hit the brief window between the renames (old binary, new
+    ``_internal``); an already-running one keeps its open inodes and is
+    unaffected. The layout validation above this call is what makes the
+    rename sequence safe to enter — nothing past the first rename can
+    discover a bad archive."""
     marker = f".old.{os.getpid()}"
     if (root / "_internal").exists():
         os.rename(root / "_internal", root / f"_internal{marker}")
@@ -448,15 +529,26 @@ def _swap(root: Path, new_app: Path, binary_name: str) -> None:
     sweep_stale(root)
 
 
+# Staging dirs younger than this may belong to an update still running
+# in another process; only provably abandoned ones are swept.
+STALE_STAGING_SECONDS = 3600.0
+
+
 def sweep_stale(root: Path) -> None:
-    """Remove leftovers earlier updates renamed aside (and abandoned
-    staging dirs). On Windows the pieces a running process still maps
+    """Remove leftovers earlier updates renamed aside, and staging dirs
+    proven abandoned (an in-flight update in another process owns a
+    *young* ``.ade-update-<pid>`` — sweeping it mid-download would abort
+    a valid update). On Windows the pieces a running process still maps
     survive the attempt — a later run's sweep gets them. Never raises."""
     try:
-        entries = [
-            *root.glob("*.old.*"),
-            *root.glob(".ade-update-*"),
-        ]
+        entries = list(root.glob("*.old.*"))
+        cutoff = time.time() - STALE_STAGING_SECONDS
+        for staging in root.glob(".ade-update-*"):
+            try:
+                if staging.stat().st_mtime < cutoff:
+                    entries.append(staging)
+            except OSError:
+                continue
     except OSError:
         return
     for entry in entries:
@@ -500,14 +592,39 @@ def _read_cache(home: Path) -> dict:
 
 
 def _write_cache(home: Path, *, latest: str | None) -> None:
+    """Publish the throttle stamp atomically (write-temp-then-replace) —
+    a reader never observes a half-written cache."""
     try:
         home.mkdir(parents=True, exist_ok=True)
-        (home / CACHE_NAME).write_text(
+        tmp = home / f".{CACHE_NAME}.tmp.{os.getpid()}"
+        tmp.write_text(
             json.dumps({"checked_at": time.time(), "latest": latest}),
             encoding="utf-8",
         )
+        os.replace(tmp, home / CACHE_NAME)
     except OSError:
         pass
+
+
+def _reserve_check(home: Path) -> bool:
+    """Whether this process may probe now: under the cross-process lock,
+    a fresh stamp means someone else already checked (or reserved) this
+    window — the at-most-once-per-24h promise holds across concurrent
+    CLIs. Reserving stamps *before* the probe; the result overwrites the
+    stamp after, and a failed probe simply leaves the reservation as the
+    attempt record."""
+    home.mkdir(parents=True, exist_ok=True)
+    with exclusive(home / CACHE_LOCK_NAME):
+        cache = _read_cache(home)
+        checked_at = cache.get("checked_at")
+        if (
+            isinstance(checked_at, (int, float))
+            and time.time() - float(checked_at) < CHECK_INTERVAL_SECONDS
+        ):
+            return False
+        previous = cache.get("latest")
+        _write_cache(home, latest=previous if isinstance(previous, str) else None)
+        return True
 
 
 def after_command(
@@ -533,18 +650,16 @@ def after_command(
         home = _home(env)
         if not check_enabled(env, home):
             return
-        cache = _read_cache(home)
-        checked_at = cache.get("checked_at")
-        if (
-            isinstance(checked_at, (int, float))
-            and time.time() - float(checked_at) < CHECK_INTERVAL_SECONDS
-        ):
+        # Reserve the window under the cross-process lock before probing:
+        # two CLIs racing a stale cache still make one probe between them.
+        if not _reserve_check(home):
             return
         try:
-            latest = fetch_latest(transport, timeout=NUDGE_TIMEOUT_SECONDS)
+            release = fetch_latest(transport, timeout=NUDGE_TIMEOUT_SECONDS)
         except UpdateCheckError:
-            latest = None
-        # Stamp the attempt whatever it answered: an unreachable channel
+            release = None
+        latest = release.version if release else None
+        # Stamp the answer over the reservation: an unreachable channel
         # must not turn into a probe per command.
         _write_cache(home, latest=latest)
         current = current_version()

--- a/src/ade_cli/update.py
+++ b/src/ade_cli/update.py
@@ -200,15 +200,28 @@ def update(
     ports: Ports = ctx.obj
     current = current_version()
     mode = install_mode()
+    # The guarantee's progress line (#33), reused for the slow parts here
+    # — the ~100 MB download most of all, which read as a hang without it.
+    # stderr only, silent under --json; imported lazily (guarantee.py
+    # imports this module for the unknown-model hint).
+    from .guarantee import Progress
+
+    progress = Progress(
+        ports.clock,
+        "off" if as_json else ("tty" if ports.stderr_is_tty() else "plain"),
+    )
+    progress.update(label="checking the release channel")
     try:
         latest = fetch_latest(ports.transport, timeout=CHECK_TIMEOUT_SECONDS)
     except UpdateCheckError as error:
+        progress.close()
         exit_with(
             {"error": "update_check_failed", "message": str(error), "current": current},
             f"Cannot check for updates: {error}.",
             as_json=as_json,
             code=EXIT_FAILED,
         )
+    progress.close()
     # The explicit check counts against the periodic throttle too — a
     # fresh `update` should buy a quiet day, whatever it concluded.
     _write_cache(_home(os.environ), latest=latest)
@@ -252,7 +265,7 @@ def update(
         if not typer.confirm(f"Update ade {current} -> {latest}?"):
             emit(payload, "Update declined; nothing changed.", as_json=as_json)
             return
-    _self_replace(ports.transport, latest=latest, as_json=as_json)
+    _self_replace(ports.transport, latest=latest, as_json=as_json, progress=progress)
     emit(
         {**payload, "updated": True},
         f"Updated ade {current} -> {latest} in {install_root()} — takes "
@@ -262,25 +275,29 @@ def update(
 
 
 def _self_replace(
-    transport: httpx.BaseTransport, *, latest: str, as_json: bool
+    transport: httpx.BaseTransport, *, latest: str, as_json: bool, progress
 ) -> None:
     """Download, verify, and swap in the latest frozen app. Mirrors
     install.sh: stage *inside* the install dir so the final steps are
     same-filesystem renames, verify against SHA256SUMS.txt before
     touching anything, and validate the archive's layout before the
     first rename — past that point every step is a rename that cannot
-    half-copy."""
+    half-copy. Every phase reports on the progress line — the download
+    runs tens of seconds and read as a hang without one."""
+
+    def fail(payload: dict, human: str) -> None:
+        progress.close()
+        exit_with(payload, human, as_json=as_json, code=EXIT_FAILED)
+
     target = platform_target()
     if target is None:
-        exit_with(
+        fail(
             {
                 "error": "unsupported_platform",
                 "platform": f"{sys.platform}-{platform.machine()}",
             },
             f"No release asset exists for this platform "
             f"({sys.platform} {platform.machine()}); re-install manually.",
-            as_json=as_json,
-            code=EXIT_FAILED,
         )
     asset = asset_name(target)
     root = install_root()
@@ -289,34 +306,43 @@ def _self_replace(
         try:
             staging.mkdir(parents=True)
         except OSError as error:
-            exit_with(
+            fail(
                 {"error": "update_failed", "message": f"cannot stage in {root}: {error}"},
                 f"Cannot write to the install directory {root} ({error}); "
                 "re-run with the permissions the install has, or re-install.",
-                as_json=as_json,
-                code=EXIT_FAILED,
             )
         archive = staging / asset
         with httpx.Client(
             transport=transport, timeout=CHECK_TIMEOUT_SECONDS, follow_redirects=True
         ) as client:
-            _download(client, f"{DOWNLOAD_BASE_URL}/{asset}", archive, as_json=as_json)
+            _download(
+                client,
+                f"{DOWNLOAD_BASE_URL}/{asset}",
+                archive,
+                progress=progress,
+                label=f"downloading {asset}",
+                fail=fail,
+            )
             sums = staging / "SHA256SUMS.txt"
             _download(
-                client, f"{DOWNLOAD_BASE_URL}/SHA256SUMS.txt", sums, as_json=as_json
+                client,
+                f"{DOWNLOAD_BASE_URL}/SHA256SUMS.txt",
+                sums,
+                progress=progress,
+                label="downloading SHA256SUMS.txt",
+                fail=fail,
             )
+        progress.update(label="verifying checksum")
         expected = _expected_sum(sums.read_text(encoding="utf-8"), asset)
         if expected is None:
-            exit_with(
+            fail(
                 {"error": "checksum_unavailable", "asset": asset},
                 f"SHA256SUMS.txt on the release has no entry for {asset}; "
                 "not installing an unverifiable download.",
-                as_json=as_json,
-                code=EXIT_FAILED,
             )
         actual = hashlib.sha256(archive.read_bytes()).hexdigest()
         if actual != expected:
-            exit_with(
+            fail(
                 {
                     "error": "checksum_mismatch",
                     "asset": asset,
@@ -325,51 +351,61 @@ def _self_replace(
                 },
                 f"Checksum mismatch for {asset} — refusing to install a "
                 "download that does not match the release's SHA256SUMS.txt.",
-                as_json=as_json,
-                code=EXIT_FAILED,
             )
+        progress.update(label="installing")
         new_dir = staging / "new"
         _extract_archive(archive, new_dir)
         # The archive holds a onedir app: ade/<binary> + ade/_internal/.
         binary_name = Path(sys.executable).name
         new_app = new_dir / "ade"
         if not (new_app / binary_name).is_file() or not (new_app / "_internal").is_dir():
-            exit_with(
+            fail(
                 {"error": "bad_release_archive", "asset": asset},
                 f"The release archive {asset} does not contain the expected "
                 "app layout; not installing it.",
-                as_json=as_json,
-                code=EXIT_FAILED,
             )
         _swap(root, new_app, binary_name)
+        progress.update(label=f"updated to {latest}")
+        progress.close()
     finally:
         shutil.rmtree(staging, ignore_errors=True)
 
 
 def _download(
-    client: httpx.Client, url: str, dest: Path, *, as_json: bool
+    client: httpx.Client, url: str, dest: Path, *, progress, label: str, fail
 ) -> None:
+    """Stream ``url`` to ``dest``, reporting received/total on the
+    progress line per chunk (tty rewrites in place; plain mode dedups to
+    one line per 10%). A body without Content-Length still shows the
+    moving label, just without a percentage."""
+    progress.update(label=label)
     try:
-        response = client.get(url)
+        with client.stream("GET", url) as response:
+            if response.status_code != 200:
+                fail(
+                    {
+                        "error": "update_download_failed",
+                        "url": url,
+                        "status_code": response.status_code,
+                    },
+                    f"Download failed for {url} (HTTP {response.status_code}).",
+                )
+            try:
+                total = int(response.headers.get("Content-Length", ""))
+            except ValueError:
+                total = 0
+            received = 0
+            with dest.open("wb") as out:
+                for chunk in response.iter_bytes():
+                    out.write(chunk)
+                    received += len(chunk)
+                    if total:
+                        progress.update(label=label, fraction=received / total)
     except httpx.HTTPError as error:
-        exit_with(
+        fail(
             {"error": "update_download_failed", "url": url, "message": str(error)},
             f"Download failed for {url}: {error}.",
-            as_json=as_json,
-            code=EXIT_FAILED,
         )
-    if response.status_code != 200:
-        exit_with(
-            {
-                "error": "update_download_failed",
-                "url": url,
-                "status_code": response.status_code,
-            },
-            f"Download failed for {url} (HTTP {response.status_code}).",
-            as_json=as_json,
-            code=EXIT_FAILED,
-        )
-    dest.write_bytes(response.content)
 
 
 def _expected_sum(sums_text: str, asset: str) -> str | None:

--- a/src/ade_cli/update.py
+++ b/src/ade_cli/update.py
@@ -1,0 +1,539 @@
+"""``update`` — keep the CLI current against a moving backend (#138).
+
+Two install modes, detected at runtime:
+
+- **Frozen binary** (``sys.frozen`` — the same seam the viewer re-exec
+  uses): download this platform's asset from the GitHub release channel
+  (versionless names, so ``releases/latest/download/...`` resolves
+  without knowing the tag), verify it against ``SHA256SUMS.txt``, and
+  replace the running app by staging inside the install dir and
+  renaming — mirroring install.sh. Windows cannot overwrite a running
+  ``.exe``: the old pieces are renamed aside (``*.old.<pid>``) and swept
+  by a later run.
+- **Python environment** (uv/pipx/pip — not frozen): an environment this
+  CLI does not manage is never mutated; ``update`` reports the newer
+  version and points at ``uv tool upgrade ade-cli``.
+
+The periodic check rides after every command's real work (the same
+post-command seam as the telemetry flush): throttled to at most one
+network probe per ~24h via a cache file under the store home, and the
+nudge goes to **stderr only** — stdout keeps its one-stable-JSON-object
+contract. Suppressed when stderr is not a TTY (scripts and agents never
+see it) and by the ``ADE_NO_UPDATE_CHECK`` variable or the
+``update_check: false`` config key. Every failure is swallowed: staying
+current is never worth failing a command. While the repo is private the
+unauthenticated check answers 404/403 — that reads as "skip silently",
+so the public transition needs nothing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import sys
+import tarfile
+import time
+import zipfile
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _installed_version
+from pathlib import Path
+from typing import Mapping
+
+import httpx
+import typer
+
+from .config import load_config
+from .output import EXIT_FAILED, EXIT_USAGE, JSON_FLAG, emit, exit_with
+from .ports import Ports
+
+REPO = "landing-ai/ade-cli"
+RELEASES_LATEST_URL = f"https://api.github.com/repos/{REPO}/releases/latest"
+# Versionless asset names (internal #76) — latest/download resolves
+# without knowing the tag, which is what makes self-update one GET.
+DOWNLOAD_BASE_URL = f"https://github.com/{REPO}/releases/latest/download"
+
+# The explicit command can afford a real wait; the piggybacked check
+# rides on someone else's invocation and must stay cheap even against a
+# black-holed network (same posture as the telemetry flush).
+CHECK_TIMEOUT_SECONDS = 10.0
+NUDGE_TIMEOUT_SECONDS = 3.0
+CHECK_INTERVAL_SECONDS = 24 * 3600.0
+CACHE_NAME = "update-check.json"
+
+
+class UpdateCheckError(Exception):
+    """The release channel could not answer the version question."""
+
+
+def is_frozen() -> bool:
+    return bool(getattr(sys, "frozen", False))
+
+
+def install_mode() -> str:
+    """How this CLI is installed: ``binary`` (the frozen standalone app —
+    self-update replaces it in place) or ``python`` (uv/pipx/pip — an
+    environment ade does not manage and never mutates)."""
+    return "binary" if is_frozen() else "python"
+
+
+def install_root() -> Path:
+    """The onedir app root: the directory holding the running binary and
+    its ``_internal/`` support dir. Meaningful only when frozen."""
+    return Path(sys.executable).resolve().parent
+
+
+def current_version() -> str:
+    try:
+        return _installed_version("ade-cli")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _parse_version(text: str) -> tuple[int, ...] | None:
+    parts = text.strip().lstrip("v").split(".")
+    try:
+        return tuple(int(part) for part in parts)
+    except ValueError:
+        return None
+
+
+def is_newer(candidate: str | None, current: str) -> bool:
+    """Whether ``candidate`` is a strictly newer release than ``current``.
+    Unparseable versions are never "newer" — a nudge must not fire on
+    garbage, and an unknown local version has nothing to compare."""
+    if candidate is None:
+        return False
+    new, old = _parse_version(candidate), _parse_version(current)
+    if new is None or old is None:
+        return False
+    return new > old
+
+
+def fetch_latest(
+    transport: httpx.BaseTransport, *, timeout: float
+) -> str | None:
+    """The latest release's version (tag without the ``v``), or None when
+    the channel is unavailable in the way that means "skip silently":
+    404/403 is what the unauthenticated API answers while the repo is
+    private (or has no release yet). Anything else — network failure, an
+    unexpected status, a malformed body — raises UpdateCheckError."""
+    try:
+        with httpx.Client(transport=transport, timeout=timeout) as client:
+            response = client.get(
+                RELEASES_LATEST_URL,
+                headers={"Accept": "application/vnd.github+json"},
+                follow_redirects=True,
+            )
+    except httpx.HTTPError as error:
+        raise UpdateCheckError(f"cannot reach the release channel: {error}")
+    if response.status_code in (403, 404):
+        return None
+    if response.status_code != 200:
+        raise UpdateCheckError(
+            f"release channel answered HTTP {response.status_code}"
+        )
+    try:
+        tag = response.json().get("tag_name")
+    except json.JSONDecodeError:
+        tag = None
+    if not isinstance(tag, str) or not tag:
+        raise UpdateCheckError("release channel sent no tag_name")
+    return tag.lstrip("v")
+
+
+# ---------------------------------------------------------------------------
+# The `ade update` command
+
+
+def platform_target() -> str | None:
+    """This machine's release-asset target (``darwin-arm64``, ...), the
+    exact vocabulary the release workflow and installers share; None for
+    a platform the release matrix does not build."""
+    machines = {
+        "arm64": "arm64",
+        "aarch64": "arm64",
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+    }
+    arch = machines.get(platform.machine().lower())
+    if arch is None:
+        return None
+    if sys.platform == "darwin":
+        return f"darwin-{arch}"
+    if sys.platform.startswith("linux"):
+        return f"linux-{arch}"
+    if sys.platform in ("win32", "cygwin"):
+        return f"windows-{arch}"
+    return None
+
+
+def asset_name(target: str) -> str:
+    ext = "zip" if target.startswith("windows-") else "tar.gz"
+    return f"ade-cli-{target}.{ext}"
+
+
+def update(
+    ctx: typer.Context,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Install without the interactive confirmation (required when "
+        "stdin is not a terminal).",
+    ),
+    as_json: bool = JSON_FLAG,
+) -> None:
+    """Check the release channel for a newer CLI and self-update on
+    confirmation. A standalone-binary install (see `ade version`)
+    replaces itself in place after verifying the release checksum; a
+    uv/pipx install is never mutated — the command reports the newer
+    version and points at `uv tool upgrade ade-cli`."""
+    ports: Ports = ctx.obj
+    current = current_version()
+    mode = install_mode()
+    try:
+        latest = fetch_latest(ports.transport, timeout=CHECK_TIMEOUT_SECONDS)
+    except UpdateCheckError as error:
+        exit_with(
+            {"error": "update_check_failed", "message": str(error), "current": current},
+            f"Cannot check for updates: {error}.",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    # The explicit check counts against the periodic throttle too — a
+    # fresh `update` should buy a quiet day, whatever it concluded.
+    _write_cache(_home(os.environ), latest=latest)
+    payload = {"current": current, "latest": latest, "updated": False, "install": mode}
+    if latest is None:
+        emit(
+            payload,
+            "The release channel has no visible release to compare against; "
+            "nothing to do.",
+            as_json=as_json,
+        )
+        return
+    if not is_newer(latest, current):
+        emit(payload, f"ade {current} is up to date (latest: {latest}).", as_json=as_json)
+        return
+    if mode == "python":
+        emit(
+            payload,
+            f"ade {latest} is available (you have {current}). This is a "
+            "Python-environment install ade does not manage — run "
+            "`uv tool upgrade ade-cli` (or your installer's equivalent) to "
+            "update.",
+            as_json=as_json,
+        )
+        return
+    if not yes:
+        if not ports.stdin_is_tty():
+            exit_with(
+                {
+                    "error": "confirm_required",
+                    "current": current,
+                    "latest": latest,
+                    "message": "pass --yes to update without a terminal to confirm on",
+                },
+                f"ade {latest} is available (you have {current}); updating "
+                "replaces the installed binary. Pass --yes to confirm "
+                "non-interactively.",
+                as_json=as_json,
+                code=EXIT_USAGE,
+            )
+        if not typer.confirm(f"Update ade {current} -> {latest}?"):
+            emit(payload, "Update declined; nothing changed.", as_json=as_json)
+            return
+    _self_replace(ports.transport, latest=latest, as_json=as_json)
+    emit(
+        {**payload, "updated": True},
+        f"Updated ade {current} -> {latest} in {install_root()} — takes "
+        "effect on the next run.",
+        as_json=as_json,
+    )
+
+
+def _self_replace(
+    transport: httpx.BaseTransport, *, latest: str, as_json: bool
+) -> None:
+    """Download, verify, and swap in the latest frozen app. Mirrors
+    install.sh: stage *inside* the install dir so the final steps are
+    same-filesystem renames, verify against SHA256SUMS.txt before
+    touching anything, and validate the archive's layout before the
+    first rename — past that point every step is a rename that cannot
+    half-copy."""
+    target = platform_target()
+    if target is None:
+        exit_with(
+            {
+                "error": "unsupported_platform",
+                "platform": f"{sys.platform}-{platform.machine()}",
+            },
+            f"No release asset exists for this platform "
+            f"({sys.platform} {platform.machine()}); re-install manually.",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    asset = asset_name(target)
+    root = install_root()
+    staging = root / f".ade-update-{os.getpid()}"
+    try:
+        try:
+            staging.mkdir(parents=True)
+        except OSError as error:
+            exit_with(
+                {"error": "update_failed", "message": f"cannot stage in {root}: {error}"},
+                f"Cannot write to the install directory {root} ({error}); "
+                "re-run with the permissions the install has, or re-install.",
+                as_json=as_json,
+                code=EXIT_FAILED,
+            )
+        archive = staging / asset
+        with httpx.Client(
+            transport=transport, timeout=CHECK_TIMEOUT_SECONDS, follow_redirects=True
+        ) as client:
+            _download(client, f"{DOWNLOAD_BASE_URL}/{asset}", archive, as_json=as_json)
+            sums = staging / "SHA256SUMS.txt"
+            _download(
+                client, f"{DOWNLOAD_BASE_URL}/SHA256SUMS.txt", sums, as_json=as_json
+            )
+        expected = _expected_sum(sums.read_text(encoding="utf-8"), asset)
+        if expected is None:
+            exit_with(
+                {"error": "checksum_unavailable", "asset": asset},
+                f"SHA256SUMS.txt on the release has no entry for {asset}; "
+                "not installing an unverifiable download.",
+                as_json=as_json,
+                code=EXIT_FAILED,
+            )
+        actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+        if actual != expected:
+            exit_with(
+                {
+                    "error": "checksum_mismatch",
+                    "asset": asset,
+                    "expected": expected,
+                    "actual": actual,
+                },
+                f"Checksum mismatch for {asset} — refusing to install a "
+                "download that does not match the release's SHA256SUMS.txt.",
+                as_json=as_json,
+                code=EXIT_FAILED,
+            )
+        new_dir = staging / "new"
+        _extract_archive(archive, new_dir)
+        # The archive holds a onedir app: ade/<binary> + ade/_internal/.
+        binary_name = Path(sys.executable).name
+        new_app = new_dir / "ade"
+        if not (new_app / binary_name).is_file() or not (new_app / "_internal").is_dir():
+            exit_with(
+                {"error": "bad_release_archive", "asset": asset},
+                f"The release archive {asset} does not contain the expected "
+                "app layout; not installing it.",
+                as_json=as_json,
+                code=EXIT_FAILED,
+            )
+        _swap(root, new_app, binary_name)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _download(
+    client: httpx.Client, url: str, dest: Path, *, as_json: bool
+) -> None:
+    try:
+        response = client.get(url)
+    except httpx.HTTPError as error:
+        exit_with(
+            {"error": "update_download_failed", "url": url, "message": str(error)},
+            f"Download failed for {url}: {error}.",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    if response.status_code != 200:
+        exit_with(
+            {
+                "error": "update_download_failed",
+                "url": url,
+                "status_code": response.status_code,
+            },
+            f"Download failed for {url} (HTTP {response.status_code}).",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    dest.write_bytes(response.content)
+
+
+def _expected_sum(sums_text: str, asset: str) -> str | None:
+    """The asset's digest from SHA256SUMS.txt (``<hex>  <name>`` lines,
+    sha256sum's own format)."""
+    for line in sums_text.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[-1].lstrip("*") == asset:
+            return parts[0].lower()
+    return None
+
+
+def _extract_archive(archive: Path, dest: Path) -> None:
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as bundle:
+            bundle.extractall(dest)
+        return
+    with tarfile.open(archive, "r:gz") as bundle:
+        try:
+            bundle.extractall(dest, filter="data")
+        except TypeError:  # Python without the extraction-filter API
+            bundle.extractall(dest)
+
+
+def _swap(root: Path, new_app: Path, binary_name: str) -> None:
+    """Every step is a same-filesystem rename: the running pieces move
+    aside to ``*.old.<pid>`` names first — Windows cannot overwrite a
+    running ``.exe`` or its mapped DLLs, but it *can* rename them — then
+    the new pieces move in. The aside-renamed leftovers are swept right
+    away where the OS allows and by a later run's sweep where it does
+    not."""
+    marker = f".old.{os.getpid()}"
+    if (root / "_internal").exists():
+        os.rename(root / "_internal", root / f"_internal{marker}")
+    os.rename(new_app / "_internal", root / "_internal")
+    if (root / binary_name).exists():
+        os.rename(root / binary_name, root / f"{binary_name}{marker}")
+    os.rename(new_app / binary_name, root / binary_name)
+    (root / binary_name).chmod(0o755)
+    sweep_stale(root)
+
+
+def sweep_stale(root: Path) -> None:
+    """Remove leftovers earlier updates renamed aside (and abandoned
+    staging dirs). On Windows the pieces a running process still maps
+    survive the attempt — a later run's sweep gets them. Never raises."""
+    try:
+        entries = [
+            *root.glob("*.old.*"),
+            *root.glob(".ade-update-*"),
+        ]
+    except OSError:
+        return
+    for entry in entries:
+        try:
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.rmtree(entry, ignore_errors=True)
+            else:
+                entry.unlink(missing_ok=True)
+        except OSError:
+            continue
+
+
+# ---------------------------------------------------------------------------
+# The post-command periodic check
+
+
+def check_enabled(env: Mapping[str, str], home: Path) -> bool:
+    """ADE_NO_UPDATE_CHECK (any value but empty/0, the DO_NOT_TRACK
+    convention) and the ``update_check: false`` config key both disable
+    the periodic check entirely."""
+    if env.get("ADE_NO_UPDATE_CHECK") not in (None, "", "0"):
+        return False
+    try:
+        if load_config(home).get("update_check") is False:
+            return False
+    except Exception:
+        pass
+    return True
+
+
+def _home(env: Mapping[str, str]) -> Path:
+    return Path(env["ADE_HOME"]) if env.get("ADE_HOME") else Path.home() / ".ade"
+
+
+def _read_cache(home: Path) -> dict:
+    try:
+        record = json.loads((home / CACHE_NAME).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return record if isinstance(record, dict) else {}
+
+
+def _write_cache(home: Path, *, latest: str | None) -> None:
+    try:
+        home.mkdir(parents=True, exist_ok=True)
+        (home / CACHE_NAME).write_text(
+            json.dumps({"checked_at": time.time(), "latest": latest}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def after_command(
+    *,
+    command: str,
+    env: Mapping[str, str],
+    transport: httpx.BaseTransport,
+    stderr_is_tty: bool,
+) -> None:
+    """The post-command entry point: sweep self-update leftovers, then —
+    at most once per ~24h, TTY-gated, opt-out respected — probe the
+    release channel and nudge on stderr. Runs after the command's output
+    and exit path are decided; never surfaces, never raises."""
+    try:
+        if is_frozen():
+            sweep_stale(install_root())
+        if command.split(" ")[0] in ("update", "version"):
+            # `update` just answered the question; `version` is often the
+            # probe scripts run — neither wants a nudge racing its output.
+            return
+        if not stderr_is_tty:
+            return
+        home = _home(env)
+        if not check_enabled(env, home):
+            return
+        cache = _read_cache(home)
+        checked_at = cache.get("checked_at")
+        if (
+            isinstance(checked_at, (int, float))
+            and time.time() - float(checked_at) < CHECK_INTERVAL_SECONDS
+        ):
+            return
+        try:
+            latest = fetch_latest(transport, timeout=NUDGE_TIMEOUT_SECONDS)
+        except UpdateCheckError:
+            latest = None
+        # Stamp the attempt whatever it answered: an unreachable channel
+        # must not turn into a probe per command.
+        _write_cache(home, latest=latest)
+        current = current_version()
+        if is_newer(latest, current):
+            typer.echo(
+                f"ade {latest} is available (you have {current}) — run "
+                "`ade update`.",
+                err=True,
+            )
+    except BaseException:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# The unknown-model hint
+
+_MODEL_ERROR_MARKERS = (
+    "unknown",
+    "unsupported",
+    "invalid",
+    "not found",
+    "unrecognized",
+    "no such",
+)
+
+
+def unknown_model_hint(detail: str | None) -> str | None:
+    """The registry-style "unknown model" server error usually means the
+    API moved past this CLI build — worth one pointer at `ade update`.
+    Matched on the server's message text (the v2 envelope pins no code
+    for it), narrowly enough that unrelated failures stay unhinted."""
+    text = (detail or "").lower()
+    if "model" in text and any(marker in text for marker in _MODEL_ERROR_MARKERS):
+        return "If the model is newer than this CLI, `ade update` may add it."
+    return None

--- a/src/ade_cli/update.py
+++ b/src/ade_cli/update.py
@@ -118,13 +118,20 @@ def fetch_latest(
     """The latest release's version (tag without the ``v``), or None when
     the channel is unavailable in the way that means "skip silently":
     404/403 is what the unauthenticated API answers while the repo is
-    private (or has no release yet). Anything else — network failure, an
-    unexpected status, a malformed body — raises UpdateCheckError."""
+    private (or has no release yet), and 403 is also its anonymous
+    rate-limit answer. An ambient GITHUB_TOKEN/GH_TOKEN rides along when
+    present — the same posture as install.sh, never stored. Anything
+    else — network failure, an unexpected status, a malformed body —
+    raises UpdateCheckError."""
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     try:
         with httpx.Client(transport=transport, timeout=timeout) as client:
             response = client.get(
                 RELEASES_LATEST_URL,
-                headers={"Accept": "application/vnd.github+json"},
+                headers=headers,
                 follow_redirects=True,
             )
     except httpx.HTTPError as error:

--- a/src/ade_cli/update.py
+++ b/src/ade_cli/update.py
@@ -40,7 +40,7 @@ import zipfile
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _installed_version
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, NoReturn
 
 import httpx
 import typer
@@ -285,7 +285,7 @@ def _self_replace(
     half-copy. Every phase reports on the progress line — the download
     runs tens of seconds and read as a hang without one."""
 
-    def fail(payload: dict, human: str) -> None:
+    def fail(payload: dict, human: str) -> NoReturn:
         progress.close()
         exit_with(payload, human, as_json=as_json, code=EXIT_FAILED)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,10 @@ class Cli:
             # POST after every invocation. Flush tests opt back in with
             # env={"ADE_TELEMETRY_UPLOAD": None}.
             "ADE_TELEMETRY_UPLOAD": "0",
+            # The periodic update check (#138) stays off the same way — it
+            # would fire an unscripted GET after any stderr-tty invocation.
+            # Nudge tests opt back in with env={"ADE_NO_UPDATE_CHECK": None}.
+            "ADE_NO_UPDATE_CHECK": "1",
             "DO_NOT_TRACK": None,
         }
         merged.update(dict.fromkeys(surface.marker_variables()))

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -53,6 +53,7 @@ def test_the_walked_tree_matches_the_expected_commands():
             ("login",),
             ("logout",),
             ("parse",),
+            ("update",),
             ("version",),
             ("view",),
         ]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -127,7 +127,7 @@ def release_archive_bytes(tmp_path, asset, binary=b"new binary"):
     """A release asset with the app layout the installers unpack:
     ade/<binary> + ade/_internal/."""
     app = tmp_path / "bundle" / "ade"
-    (app / "_internal").mkdir(parents=True)
+    (app / "_internal").mkdir(parents=True, exist_ok=True)
     (app / "_internal" / "new-lib.bin").write_bytes(b"new lib")
     (app / "ade").write_bytes(binary)
     buffer = io.BytesIO()
@@ -182,6 +182,30 @@ def test_frozen_update_verifies_downloads_and_swaps_atomically(
     urls = [str(request.url) for request in cli.transport.requests]
     assert urls[1] == f"{update_mod.DOWNLOAD_BASE_URL}/{asset}"
     assert urls[2] == f"{update_mod.DOWNLOAD_BASE_URL}/SHA256SUMS.txt"
+
+
+def test_frozen_update_reports_progress_on_stderr(cli, tmp_path, frozen_install):
+    # The download runs tens of seconds against the real channel and read
+    # as a hang without feedback. Milestones ride the guarantee's
+    # progress line: stderr only (stdout keeps the summary), silent
+    # under --json.
+    asset = script_release(cli, tmp_path)
+
+    result = cli.invoke("update", "--yes")
+
+    assert result.exit_code == 0, result.stdout
+    assert f"downloading {asset}" in result.stderr
+    assert "verifying checksum" in result.stderr
+    assert "installing" in result.stderr
+    assert "updated to 99.0.0" in result.stderr
+    assert "downloading" not in result.stdout
+
+    # --json stays fully silent on both streams.
+    (frozen_install / "ade").write_bytes(b"old binary")
+    script_release(cli, tmp_path)
+    silent = cli.invoke("update", "--yes", "--json")
+    assert silent.exit_code == 0
+    assert silent.stderr == ""
 
 
 def test_frozen_update_refuses_a_checksum_mismatch(cli, tmp_path, frozen_install):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -65,6 +65,26 @@ def test_update_up_to_date_reports_and_changes_nothing(cli):
     assert payload["latest"] == installed_version("ade-cli")
 
 
+def test_an_ambient_github_token_rides_on_the_version_check(cli):
+    # install.sh's posture: a GITHUB_TOKEN/GH_TOKEN in the environment is
+    # used, never stored — it lifts the anonymous API rate limit and
+    # covers the private-repo window.
+    script_latest(cli, "v99.0.0")
+
+    result = cli.invoke(
+        "update", "--json", env={"GITHUB_TOKEN": "ghp_test_token"}
+    )
+
+    assert result.exit_code == 0
+    (request,) = cli.transport.requests
+    assert request.headers["Authorization"] == "Bearer ghp_test_token"
+
+    script_latest(cli, "v99.0.0")
+    bare = cli.invoke("update", "--json", env={"GITHUB_TOKEN": None, "GH_TOKEN": None})
+    assert bare.exit_code == 0
+    assert "Authorization" not in cli.transport.requests[-1].headers
+
+
 def test_update_skips_silently_when_the_release_channel_is_not_visible(cli):
     # 404 is what the unauthenticated API answers while the repo is
     # private (or has no release yet): nothing to compare, not a failure.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,332 @@
+"""``update`` — self-update against the GitHub release channel (#138),
+driven through the CLI seam.
+
+The release channel is the fake transport: the version probe, the asset
+download, and SHA256SUMS.txt are all scripted. The frozen-binary mode is
+entered through the same seam the viewer re-exec uses (``sys.frozen`` +
+``sys.executable``), pointed at a fake install dir under tmp_path — the
+swap is asserted on real files.
+"""
+
+import hashlib
+import io
+import json
+import sys
+import tarfile
+import zipfile
+from importlib.metadata import version as installed_version
+
+import httpx
+import pytest
+
+from ade_cli import update as update_mod
+
+KEY = "sk-test-0123456789abcd"
+
+
+def script_latest(cli, tag="v99.0.0", status=200):
+    cli.transport.respond(status, {"tag_name": tag} if status == 200 else {})
+
+
+# --- version check, python-mode install ------------------------------------
+
+
+def test_update_reports_newer_version_and_points_at_uv_for_python_installs(cli):
+    script_latest(cli, "v99.0.0")
+
+    result = cli.invoke("update", "--json")
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "current": installed_version("ade-cli"),
+        "latest": "99.0.0",
+        "updated": False,
+        "install": "python",
+    }
+    (request,) = cli.transport.requests
+    assert request.url == update_mod.RELEASES_LATEST_URL
+
+    script_latest(cli, "v99.0.0")
+    human = cli.invoke("update")
+    assert human.exit_code == 0
+    # A Python environment ade does not manage is never mutated.
+    assert "uv tool upgrade ade-cli" in human.stdout
+
+
+def test_update_up_to_date_reports_and_changes_nothing(cli):
+    script_latest(cli, f"v{installed_version('ade-cli')}")
+
+    result = cli.invoke("update", "--json")
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["updated"] is False
+    assert payload["latest"] == installed_version("ade-cli")
+
+
+def test_update_skips_silently_when_the_release_channel_is_not_visible(cli):
+    # 404 is what the unauthenticated API answers while the repo is
+    # private (or has no release yet): nothing to compare, not a failure.
+    cli.transport.respond(404, {"message": "Not Found"})
+
+    result = cli.invoke("update", "--json")
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["latest"] is None
+
+
+def test_update_check_failure_is_a_structured_error(cli):
+    cli.transport.respond(500, {"message": "boom"})
+
+    result = cli.invoke("update", "--json")
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "update_check_failed"
+
+
+# --- frozen-binary self-replace ---------------------------------------------
+
+
+@pytest.fixture
+def frozen_install(tmp_path, monkeypatch):
+    """A fake onedir install this process 'runs from': sys.frozen plus
+    sys.executable pointed inside it — the same seam the viewer re-exec
+    reads."""
+    root = tmp_path / "install"
+    (root / "_internal").mkdir(parents=True)
+    (root / "_internal" / "old-lib.bin").write_bytes(b"old lib")
+    binary = root / "ade"
+    binary.write_bytes(b"old binary")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(binary))
+    return root
+
+
+def release_archive_bytes(tmp_path, asset, binary=b"new binary"):
+    """A release asset with the app layout the installers unpack:
+    ade/<binary> + ade/_internal/."""
+    app = tmp_path / "bundle" / "ade"
+    (app / "_internal").mkdir(parents=True)
+    (app / "_internal" / "new-lib.bin").write_bytes(b"new lib")
+    (app / "ade").write_bytes(binary)
+    buffer = io.BytesIO()
+    if asset.endswith(".zip"):
+        with zipfile.ZipFile(buffer, "w") as bundle:
+            for path in sorted(app.rglob("*")):
+                bundle.write(path, "ade/" + str(path.relative_to(app)))
+    else:
+        with tarfile.open(fileobj=buffer, mode="w:gz") as bundle:
+            bundle.add(app, arcname="ade")
+    return buffer.getvalue()
+
+
+def script_release(cli, tmp_path, *, corrupt_sums=False):
+    """Script the whole self-update conversation: the version probe, the
+    platform asset, and SHA256SUMS.txt."""
+    asset = update_mod.asset_name(update_mod.platform_target())
+    payload = release_archive_bytes(tmp_path, asset)
+    digest = hashlib.sha256(payload).hexdigest()
+    if corrupt_sums:
+        digest = "0" * 64
+    script_latest(cli, "v99.0.0")
+    cli.transport.respond_with(lambda request: httpx.Response(200, content=payload))
+    cli.transport.respond_with(
+        lambda request: httpx.Response(
+            200, content=f"{digest}  {asset}\n".encode()
+        )
+    )
+    return asset
+
+
+def test_frozen_update_verifies_downloads_and_swaps_atomically(
+    cli, tmp_path, frozen_install
+):
+    asset = script_release(cli, tmp_path)
+
+    result = cli.invoke("update", "--yes", "--json")
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["updated"] is True
+    assert payload["install"] == "binary"
+    assert payload["latest"] == "99.0.0"
+    # The swap really happened, and the whole app moved together.
+    assert (frozen_install / "ade").read_bytes() == b"new binary"
+    assert (frozen_install / "_internal" / "new-lib.bin").exists()
+    assert not (frozen_install / "_internal" / "old-lib.bin").exists()
+    # Staging and aside-renamed leftovers are gone (POSIX sweeps in-run).
+    assert not list(frozen_install.glob(".ade-update-*"))
+    assert not list(frozen_install.glob("*.old.*"))
+    # The conversation hit the versionless latest/download URLs.
+    urls = [str(request.url) for request in cli.transport.requests]
+    assert urls[1] == f"{update_mod.DOWNLOAD_BASE_URL}/{asset}"
+    assert urls[2] == f"{update_mod.DOWNLOAD_BASE_URL}/SHA256SUMS.txt"
+
+
+def test_frozen_update_refuses_a_checksum_mismatch(cli, tmp_path, frozen_install):
+    script_release(cli, tmp_path, corrupt_sums=True)
+
+    result = cli.invoke("update", "--yes", "--json")
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "checksum_mismatch"
+    # Nothing swapped, nothing staged left behind.
+    assert (frozen_install / "ade").read_bytes() == b"old binary"
+    assert (frozen_install / "_internal" / "old-lib.bin").exists()
+    assert not list(frozen_install.glob(".ade-update-*"))
+
+
+def test_frozen_update_without_a_terminal_requires_yes(
+    cli, tmp_path, frozen_install
+):
+    script_latest(cli, "v99.0.0")
+
+    result = cli.invoke("update", "--json")  # stdin is not a tty, no --yes
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["error"] == "confirm_required"
+    assert (frozen_install / "ade").read_bytes() == b"old binary"
+
+
+def test_frozen_update_confirmation_declined_changes_nothing(
+    cli, tmp_path, frozen_install
+):
+    cli.stdin_tty = True
+    script_latest(cli, "v99.0.0")
+
+    result = cli.invoke("update", input="n\n")
+
+    assert result.exit_code == 0
+    assert "nothing changed" in result.stdout
+    assert (frozen_install / "ade").read_bytes() == b"old binary"
+    assert len(cli.transport.requests) == 1  # probe only, no download
+
+
+def test_a_later_run_sweeps_windows_style_leftovers(cli, frozen_install):
+    # Windows cannot delete the running .exe or its mapped DLLs during
+    # the swap; they are renamed aside and swept by a later run — any
+    # command's post-run hook, exercised here through the seam.
+    (frozen_install / "ade.old.123").write_bytes(b"stale")
+    (frozen_install / "_internal.old.123").mkdir()
+
+    result = cli.invoke("history", "list", "--json")
+
+    assert result.exit_code == 0
+    assert not (frozen_install / "ade.old.123").exists()
+    assert not (frozen_install / "_internal.old.123").exists()
+
+
+# --- the periodic check + nudge ---------------------------------------------
+
+NUDGE_ENV = {"ADE_NO_UPDATE_CHECK": None}  # opt back in past the harness shield
+
+
+def test_a_command_nudges_on_stderr_once_a_day_when_newer_exists(cli):
+    cli.stderr_tty = True
+    script_latest(cli, "v99.0.0")
+
+    first = cli.invoke("history", "list", "--json", env=NUDGE_ENV)
+
+    assert first.exit_code == 0
+    # stdout keeps its one-stable-JSON-object contract; the nudge is
+    # stderr-only.
+    assert json.loads(first.stdout) == []
+    assert "ade 99.0.0 is available" in first.stderr
+    assert "ade update" in first.stderr
+    assert len(cli.transport.requests) == 1
+    assert (cli.home / update_mod.CACHE_NAME).exists()
+
+    # Within the throttle window: no probe, no repeat nudge.
+    second = cli.invoke("history", "list", "--json", env=NUDGE_ENV)
+    assert second.exit_code == 0
+    assert "ade update" not in second.stderr
+    assert len(cli.transport.requests) == 1
+
+
+def test_the_nudge_is_suppressed_without_a_tty(cli):
+    result = cli.invoke("history", "list", "--json", env=NUDGE_ENV)
+
+    assert result.exit_code == 0
+    assert cli.transport.requests == []  # never even probed
+
+
+def test_the_nudge_opt_out_is_respected(cli):
+    cli.stderr_tty = True
+
+    result = cli.invoke("history", "list", "--json")  # shield stays on
+
+    assert result.exit_code == 0
+    assert cli.transport.requests == []
+
+
+def test_a_failed_check_never_surfaces_and_stamps_the_throttle(cli):
+    cli.stderr_tty = True
+    cli.transport.respond(500, {"message": "boom"})
+
+    first = cli.invoke("history", "list", "--json", env=NUDGE_ENV)
+
+    assert first.exit_code == 0
+    assert "update" not in first.stderr
+    # The attempt is stamped: an unreachable channel is one probe per
+    # day, not one per command.
+    second = cli.invoke("history", "list", "--json", env=NUDGE_ENV)
+    assert second.exit_code == 0
+    assert len(cli.transport.requests) == 1
+
+
+def test_running_update_itself_buys_a_quiet_day(cli):
+    script_latest(cli, "v99.0.0")
+    checked = cli.invoke("update", "--json")
+    assert checked.exit_code == 0
+
+    cli.stderr_tty = True
+    result = cli.invoke("history", "list", "--json", env=NUDGE_ENV)
+
+    assert result.exit_code == 0
+    assert len(cli.transport.requests) == 1  # update's own probe, nothing since
+
+
+# --- the unknown-model hint ---------------------------------------------------
+
+
+def test_an_unknown_model_rejection_hints_at_update(cli, tmp_path):
+    doc = tmp_path / "invoice.pdf"
+    doc.write_bytes(b"%PDF-1.4 bytes")
+    cli.transport.respond(
+        422, {"code": "validation_error", "message": "Unknown model 'dpt-4-pro'"}
+    )
+
+    result = cli.invoke(
+        "parse", "-d", str(doc), "--model", "dpt-4-pro", "--json",
+        env={"ADE_API_KEY": KEY},
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "http"
+    assert "ade update" in payload["hint"]
+
+    cli.transport.respond(
+        422, {"code": "validation_error", "message": "Unknown model 'dpt-4-pro'"}
+    )
+    human = cli.invoke(
+        "parse", "-d", str(doc), "--model", "dpt-4-pro", env={"ADE_API_KEY": KEY}
+    )
+    assert human.exit_code == 1
+    assert "ade update" in human.stdout
+
+
+def test_unrelated_http_errors_carry_no_update_hint(cli, tmp_path):
+    doc = tmp_path / "invoice.pdf"
+    doc.write_bytes(b"%PDF-1.4 bytes")
+    cli.transport.respond(
+        422, {"code": "validation_error", "message": "options.pages out of range"}
+    )
+
+    result = cli.invoke("parse", "-d", str(doc), "--json", env={"ADE_API_KEY": KEY})
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "http"
+    assert "hint" not in payload

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -11,8 +11,10 @@ swap is asserted on real files.
 import hashlib
 import io
 import json
+import os
 import sys
 import tarfile
+import time
 import zipfile
 from importlib.metadata import version as installed_version
 
@@ -253,12 +255,82 @@ def test_a_later_run_sweeps_windows_style_leftovers(cli, frozen_install):
     # command's post-run hook, exercised here through the seam.
     (frozen_install / "ade.old.123").write_bytes(b"stale")
     (frozen_install / "_internal.old.123").mkdir()
+    # A *young* staging dir may be another process's in-flight update —
+    # sweeping it mid-download would abort a valid update; only a
+    # provably abandoned one (past the staleness window) is swept.
+    active = frozen_install / ".ade-update-999"
+    active.mkdir()
+    abandoned = frozen_install / ".ade-update-777"
+    abandoned.mkdir()
+    stale = time.time() - 2 * update_mod.STALE_STAGING_SECONDS
+    os.utime(abandoned, (stale, stale))
 
     result = cli.invoke("history", "list", "--json")
 
     assert result.exit_code == 0
     assert not (frozen_install / "ade.old.123").exists()
     assert not (frozen_install / "_internal.old.123").exists()
+    assert active.exists()
+    assert not abandoned.exists()
+
+
+def test_a_token_downloads_assets_through_the_github_api(
+    cli, tmp_path, frozen_install
+):
+    # While the repo is private, latest/download 404s even with a valid
+    # token — the authenticated path is the release-assets API, resolved
+    # from the asset ids the version probe already returned (install.sh's
+    # fetch_api).
+    asset = update_mod.asset_name(update_mod.platform_target())
+    payload = release_archive_bytes(tmp_path, asset)
+    digest = hashlib.sha256(payload).hexdigest()
+    cli.transport.respond(
+        200,
+        {
+            "tag_name": "v99.0.0",
+            "assets": [
+                {"name": asset, "id": 111},
+                {"name": "SHA256SUMS.txt", "id": 222},
+            ],
+        },
+    )
+    cli.transport.respond_with(lambda request: httpx.Response(200, content=payload))
+    cli.transport.respond_with(
+        lambda request: httpx.Response(200, content=f"{digest}  {asset}\n".encode())
+    )
+
+    result = cli.invoke("update", "--yes", "--json", env={"GITHUB_TOKEN": "ghp_x"})
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["updated"] is True
+    urls = [str(request.url) for request in cli.transport.requests]
+    assert urls[1].endswith("/releases/assets/111")
+    assert urls[2].endswith("/releases/assets/222")
+    for request in cli.transport.requests[1:]:
+        assert request.headers["Authorization"] == "Bearer ghp_x"
+        assert request.headers["Accept"] == "application/octet-stream"
+
+
+def test_a_malformed_but_checksummed_archive_is_a_structured_error(
+    cli, tmp_path, frozen_install
+):
+    # Correct checksum, garbage bytes: extraction must exit through the
+    # structured bad_release_archive path, never a traceback.
+    garbage = b"not an archive at all"
+    digest = hashlib.sha256(garbage).hexdigest()
+    asset = update_mod.asset_name(update_mod.platform_target())
+    script_latest(cli, "v99.0.0")
+    cli.transport.respond_with(lambda request: httpx.Response(200, content=garbage))
+    cli.transport.respond_with(
+        lambda request: httpx.Response(200, content=f"{digest}  {asset}\n".encode())
+    )
+
+    result = cli.invoke("update", "--yes", "--json")
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "bad_release_archive"
+    assert (frozen_install / "ade").read_bytes() == b"old binary"
+    assert not list(frozen_install.glob(".ade-update-*"))
 
 
 # --- the periodic check + nudge ---------------------------------------------

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,4 +13,9 @@ def test_version_json_emits_one_stable_object(cli):
     result = cli.invoke("version", "--json")
 
     assert result.exit_code == 0
-    assert json.loads(result.stdout) == {"version": installed_version("ade-cli")}
+    # The install mode rides along (#138): the test runner is never the
+    # frozen binary, so the mode here is always "python".
+    assert json.loads(result.stdout) == {
+        "version": installed_version("ade-cli"),
+        "install": "python",
+    }


### PR DESCRIPTION
Closes #138.

Adds `ade update` plus the surrounding lifecycle plumbing, per the issue's acceptance criteria.

## The command

- **`ade update`** checks `GET /repos/landing-ai/ade-cli/releases/latest` (unauthenticated; a 404/403 — repo private or no release yet — reads as "skip silently", so the public transition needs nothing) and compares against the running version.
- **`--json`** emits `{current, latest, updated, install}`; **`--yes`** confirms non-interactively and is required when stdin is not a terminal (structured `confirm_required` usage error otherwise).
- **Frozen binary** (`sys.frozen`, the same seam the viewer re-exec uses): downloads the platform's versionless asset from `releases/latest/download/…`, **verifies it against `SHA256SUMS.txt`** (refusing on mismatch or a missing entry), validates the archive layout, then swaps by staging *inside* the install dir and renaming — mirroring install.sh's stage-in-destination-then-rename. **Windows wrinkle**: a running `.exe` (and its mapped DLLs) can't be overwritten, so the old pieces rename aside to `*.old.<pid>`; a later run's post-command sweep removes them.
- **uv/pipx installs are never mutated**: `update` detects the mode and points at `uv tool upgrade ade-cli`.

## Periodic check + nudge

Rides the same post-command seam as the telemetry flush (`LedgerGroup.main`'s finally): throttled to at most one probe per ~24h via `~/.ade/update-check.json` (failed probes stamp the throttle too, so an unreachable channel costs one probe a day, not one per command), **stderr-only** (stdout keeps its one-stable-JSON-object contract), suppressed when stderr is not a TTY, and opted out by `ADE_NO_UPDATE_CHECK` or the `update_check: false` config key. Every failure is swallowed. An explicit `ade update` run stamps the throttle, buying a quiet day.

## Surrounding surface

- Registry-style **"unknown model" server errors** now carry the hint `If the model is newer than this CLI, ade update may add it` in both the human line and the machine payload (`hint`).
- **`ade version`** reports the install mode: `{"version": …, "install": "binary"|"python"}` / `ade 1.0.0 (standalone binary)`.
- Install mechanism + mode documented in the command help, the `help --json` result shapes (regenerated snapshot), and a README paragraph.
- Test harness shields the new post-command probe the same way it shields telemetry shipping (`ADE_NO_UPDATE_CHECK=1` baseline; nudge tests opt back in).

## Follow-ups from local verification

- **Progress line** (field report: the ~100 MB download read as a hang): every phase of the frozen self-update now reports on the guarantee's stderr progress line — live-rewriting with percent and elapsed on a TTY (`downloading ade-cli-darwin-arm64.tar.gz 50% · 9s`), one milestone per phase when piped, fully silent under `--json`. The download streams, so the percentage is real.
- **Ambient `GITHUB_TOKEN`**: the anonymous GitHub API 403s not only for a private repo but also when an IP's 60/hr quota is exhausted, and both read as "skip silently" — so `ade update` on a busy network reported no visible release. The version check now rides an ambient `GITHUB_TOKEN`/`GH_TOKEN` exactly like install.sh — used when present, never stored.
- Verified end-to-end against the live release channel: a locally-built 0.9.0 frozen binary self-updated to the real v1.0.0 release (checksum verified, atomic swap, no leftovers) in ~20s.

## Tests (18 new)

Version check + python-mode direction, up-to-date, 404-silent, structured check failure; frozen self-replace end-to-end against a fake install dir (checksum verified, swap asserted on real files, staging/leftovers swept), checksum-mismatch refusal, confirm-required, declined confirmation, Windows-style leftover sweep on a later run; nudge on stderr with 24h throttle, TTY gating, opt-out, swallowed failures, update-buys-a-quiet-day; unknown-model hint (and its absence on unrelated errors); the ambient GITHUB_TOKEN riding the version check (and absent without one); progress milestones on stderr during the frozen update (and full silence under --json).

Full suite: 595 passed; `ruff check` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

