### PR TITLE
history list: keep every table column on-screen

### DIFF
--- a/src/ade_cli/history.py
+++ b/src/ade_cli/history.py
@@ -157,7 +157,9 @@ def _render_table(jobs: store.JobStore, rows: list[tuple[dict, bool]]) -> None:
 
     cells = [
         (
-            ("  " if indent else "") + record["job_item_id"],
+            # Child rows (extracts under their parse) carry a tree marker,
+            # not bare indentation — two leading spaces read as misalignment.
+            ("└ " if indent else "") + record["job_item_id"],
             record["kind"],
             record["state"],
             # Items from before the environment field read as "?", never a
@@ -167,24 +169,43 @@ def _render_table(jobs: store.JobStore, rows: list[tuple[dict, bool]]) -> None:
         )
         for record, indent in rows
     ]
-    # Fix the five data columns at their content width so rich never
-    # shrinks them; SOURCE alone absorbs the terminal width.
     headers = ("JOB ITEM", "KIND", "STATE", "ENV", "PARAMS")
     widths = [
         max(len(header), *(len(row[i]) for row in cells))
         for i, header in enumerate(headers)
     ]
+    # The identity columns (id, kind, state, env) are naturally narrow and
+    # fix at content width so rich never shrinks them. PARAMS takes what
+    # the terminal leaves after those plus a floor for SOURCE — and wraps
+    # inside its own cell when longer, so no column ever pushes another
+    # off-screen. Under box.SIMPLE each column costs two padding cells
+    # (minus the outer pair, pad_edge=False) plus a divider cell between
+    # columns; undercounting this is what used to tip rich into its crop
+    # cascade, which shaves the pinned columns too.
+    ncols = 6
+    overhead = (2 * ncols - 2) + (ncols - 1)
+    widths[4] = min(
+        widths[4],
+        40,  # a params cell is a summary; past this, SOURCE needs it more
+        max(12, console.width - sum(widths[:4]) - overhead - 12),
+    )
     table = Table(box=box.SIMPLE, show_edge=False, pad_edge=False, header_style="bold")
-    for header, width_ in zip(headers, widths):
+    for header, width_ in zip(headers[:4], widths[:4]):
         # width alone is advisory under overflow; min_width pins it so a
         # narrow terminal crops SOURCE, never the identity columns.
         table.add_column(header, no_wrap=True, width=width_, min_width=width_)
+    # overflow="fold" wraps params onto continuation lines within the cell
+    # (even a single long token); the full value lives in --json.
+    table.add_column(
+        "PARAMS", width=widths[4], min_width=widths[4], overflow="fold"
+    )
     table.add_column("SOURCE", no_wrap=True)
 
-    # Budget for SOURCE: what the other columns and their padding leave
-    # over. Sources truncate from the left so the basename stays visible;
-    # the full source lives in --json.
-    budget = max(16, console.width - sum(widths) - 2 * 6 - 2)
+    # Budget for SOURCE: exactly what the other columns and the overhead
+    # leave over, so the table never exceeds the terminal. Sources truncate
+    # from the left so the basename stays visible; the full source lives
+    # in --json.
+    budget = max(8, console.width - sum(widths) - overhead)
     for (record, _indent), row in zip(rows, cells):
         source = tilde(record["source"]) if record["source"] else "?"
         if (record.get("parse") or {}).get("missing"):

--- a/src/ade_cli/items.py
+++ b/src/ade_cli/items.py
@@ -285,7 +285,9 @@ def artifact_index(store: JobStore, item_id: str) -> list[dict]:
 
 def compact_params(record: dict) -> str:
     """The one-line params rendering history rows and the sidebar share:
-    model, pages, tier for parse; schema field list + model for extract."""
+    model, pages, tier for parse; model + schema field count for extract.
+    The field *names* stay out — a big schema would drown every other
+    column — the full list lives in ``--json``."""
     params = record.get("params") or {}
     if record["kind"] == "parse":
         parts = [params.get("model") or "?"]
@@ -295,10 +297,11 @@ def compact_params(record: dict) -> str:
         if params.get("tier"):
             parts.append(params["tier"])
         return " · ".join(parts)
+    parts = [params.get("model") or "?"]
     fields = record.get("fields") or []
-    parts = [", ".join(fields) or "?"]
-    if params.get("model"):
-        parts.append(params["model"])
+    if fields:
+        plural = "s" if len(fields) != 1 else ""
+        parts.append(f"{len(fields)} field{plural}")
     return " · ".join(parts)
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -163,6 +163,58 @@ def test_referencing_extract_renders_as_an_indented_child_row(
     assert lines.index(child_line) == lines.index(parse_line) + 1
 
 
+def test_params_show_a_field_count_never_the_schema_field_names(
+    cli, document, schema_file
+):
+    """A big schema used to drown every other column (#134-style listing
+    rot): the human params cell says how many fields, not which — the full
+    list stays in --json and the record's ``fields``."""
+    parse_id = parse_file(cli, document)
+    extract_id = extract_item(cli, parse_id, schema_file)
+
+    human = cli.invoke("history", "list")
+    assert "2 fields" in human.stdout
+    assert "total, vendor" not in human.stdout
+    assert "extract-latest" in human.stdout  # the model still renders
+
+    # The sidebar read model shares the same compact rendering.
+    cli.invoke("history", "list", "--json")
+    by_id = {item["id"]: item for item in history_js_items(cli)}
+    assert by_id[extract_id]["params"] == "extract-latest · 2 fields"
+
+    # And the machine payload keeps the exact field list.
+    result = cli.invoke("history", "list", "--json")
+    records = {r["job_item_id"]: r for r in json.loads(result.stdout)}
+    assert records[extract_id]["fields"] == ["total", "vendor"]
+
+
+@pytest.mark.parametrize("columns", ["120", "80"])
+def test_history_table_keeps_every_column_inside_the_terminal(
+    cli, document, schema_file, columns
+):
+    """The TTY table never lets one column push another off-screen: all
+    six headers render, ids stay whole, child rows carry the tree marker,
+    and no line exceeds the terminal width."""
+    parse_id = parse_file(cli, document)
+    extract_id = extract_item(cli, parse_id, schema_file)
+    cli.stdout_tty = True
+
+    result = cli.invoke("history", "list", env={"COLUMNS": columns})
+
+    assert result.exit_code == 0
+    lines = result.stdout.splitlines()
+    header = lines[0]
+    for name in ("JOB ITEM", "KIND", "STATE", "ENV", "PARAMS", "SOURCE"):
+        assert name in header
+    assert all(len(line) <= int(columns) for line in lines)
+    # Identity columns never crop, whatever the width.
+    assert any(line.startswith(parse_id) for line in lines)
+    assert any(line.startswith(f"└ {extract_id}") for line in lines)
+    assert "extract " in result.stdout  # KIND never crops to "extra…"
+    assert "extracted" in result.stdout
+    assert "production" in result.stdout
+
+
 def test_history_states_derive_from_tickets_zero_api_calls(cli, tmp_path):
     pending_doc = tmp_path / "pending.pdf"
     pending_doc.write_bytes(b"%PDF pending bytes")


### PR DESCRIPTION
## Problem

With a store full of extract items carrying large schemas, `ade history` was unreadable: the PARAMS column grew to its content (the full schema field list), which pushed the table past the terminal and tipped rich into its overflow crop cascade — KIND/STATE/ENV disappeared entirely, job ids cropped to `e71f5b…`, and SOURCE shrank to a few characters. Child rows' bare two-space indentation also read as misalignment.

## Changes

- **Schema fields stay out of the table.** `compact_params` renders a field *count* for extract items (`extract-latest · 8 fields`) instead of every field name; the full list still rides in `--json` (`fields`) and nothing rendered the sidebar's `params` string anyway.
- **PARAMS can no longer push other columns off-screen.** It is capped at the terminal budget (hard cap 40) and wraps onto continuation lines inside its own cell (`overflow="fold"`); everything longer lives in `--json`.
- **Fixed the width math.** rich's per-column overhead under `box.SIMPLE` is two padding cells plus one divider cell between columns; the old budget undercounted by one, which was enough to trigger the crop cascade — and that cascade shaves even `min_width`-pinned columns.
- **SOURCE yields first.** On narrow terminals SOURCE shrinks below its old 16-char floor before rich ever has to crop the identity columns.
- **Child rows carry a `└` tree marker** instead of bare indentation, so the parse→extract grouping reads as deliberate. The piped (non-TTY) plain format keeps its stable two-space indent.

## After (100 columns)

```
JOB ITEM             KIND      STATE        ENV          PARAMS                         SOURCE
────────────────────────────────────────────────────────────────────────────────────────────────────
00c9714b8e5f2a67     parse     parsed       production   dpt-3-pro-latest · priority    …l_panel.pdf
└ 0ef3a92c7d4b8156   extract   extracted    production   extract-latest · 8 fields      …l_panel.pdf
└ 7380c5e2a9f1d648   extract   extracted    production   extract-latest · 20 fields     …l_panel.pdf
2e84ff6b3c9a1d75     parse     pending      production   ?                              …tch_007.pdf
```

## Testing

- Two new tests: params render a field count (never the field names, table + sidebar read model) and the TTY table keeps all six columns inside the terminal at 120 and 80 columns with un-cropped ids and the tree marker.
- Verified visually against a seeded 14-item store (parses, referencing extracts with 20-field schemas, unreadable/pending/partial items) at 140/100/80 columns under a real pty.
- Full suite: 579 passed; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)