### PR TITLE
feat: make browser OAuth a default login method (delete the ADE_OAUTH gate)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -105,7 +105,7 @@ way. OAuth logins verify themselves through the token exchange.
 _Avoid_: validation against a dedicated auth route (none exists in the v2 contract)
 
 **Provider**:
-The per-environment Logto coordinates the browser login runs against: issuer (`login.*`, never the `logto.*` admin portal), client id, and the RFC 8707 resource indicator (the token audience — the environment's API endpoint). Defaults are data; `config.json`'s `oauth.<environment>` block overrides field by field. Browser login ships dark at launch behind `ADE_OAUTH=1` (ADR-0004) — the platform has not deployed OAuth authz to production/eu.
+The per-environment Logto coordinates the browser login runs against: issuer (`login.*`, never the `logto.*` admin portal), client id, and the RFC 8707 resource indicator (the token audience — the environment's API endpoint). Defaults are data; `config.json`'s `oauth.<environment>` block overrides field by field. Browser login is a public login method (ADR-0008; ADR-0004's launch gate is deleted now that the platform accepts OIDC tokens).
 
 **OAuth session**:
 The refreshable browser-login credential for one environment: access + refresh tokens, identity, expiry. Access tokens refresh silently near expiry or once after a 401; refresh tokens rotate on every use, so refresh holds a cross-process lock and re-reads before spending one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ no Python required.
 - `CONTEXT.md` — the domain glossary. Use its vocabulary in issues,
   PRs, and code; don't drift to the synonyms it explicitly avoids.
 - `docs/adr/` — decisions with their whys (e.g. ADR-0003 per-invocation
-  environments, ADR-0004 browser OAuth dark at launch behind
-  `ADE_OAUTH=1`).
+  environments, ADR-0004/ADR-0008 browser OAuth dark at launch, then
+  public).
 - `SKILL.md` + `docs/reference/help.json` — the agent contract. `help`
   is generated from the live command tree; regenerate the committed
   snapshot after any surface change:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ billed parse/extract results.
 
 | command | what it does |
 |---|---|
-| `ade auth login` | prompt for an API key (hidden input) |
+| `ade auth login` | choose a method: paste an API key, or sign in with your browser (OAuth) |
 | `ade auth login --api-key KEY` | store an API key for production directly |
 | `ade auth login --api-key -` | prompt for the key (hidden input) |
 | `echo $KEY \| ade auth login` | headless: a piped key is the prompt, answered |
@@ -68,7 +68,8 @@ billed parse/extract results.
 | `ade login` | top-level alias of `ade auth login` — same flags, same behavior |
 | `ade logout` | top-level alias of `ade auth logout` — same flags, same behavior |
 
-API keys come from your
+Browser sign-in runs an OAuth flow against your LandingAI account and
+stores refreshable tokens; nothing to copy. API keys come from your
 [LandingAI account settings](https://ade.landing.ai/settings/api-key).
 `login` verifies the key against the target environment before storing
 it — a mistyped key fails right at login, not at your first `parse`.
@@ -103,7 +104,8 @@ on — CI, cron, an agent harness, a wrapped shell — set `ADE_API_KEY`, or
 pipe the key in: `echo $KEY | ade auth login` stores it for the resolved
 environment exactly as the prompt would. (`--api-key KEY` works too, but an
 inline key is visible to `ps`.) Nothing hangs waiting on an idle stdin: with
-no key available the command exits immediately, naming all three paths.
+no key available the login tries browser sign-in, and where no browser can
+open it exits immediately, naming all three paths.
 `ade help credentials` is the same page from the CLI.
 
 ## Parse

--- a/docs/adr/0004-oauth-dark-at-launch.md
+++ b/docs/adr/0004-oauth-dark-at-launch.md
@@ -1,6 +1,7 @@
 # ADR-0004: Browser OAuth ships dark at launch, behind `ADE_OAUTH=1`
 
-Date: 2026-07-23 · Status: accepted
+Date: 2026-07-23 · Status: superseded by ADR-0008 (the platform
+deployed OAuth authz; the gate is deleted and browser login is public)
 
 ## Context
 

--- a/docs/adr/0008-oauth-login-goes-public.md
+++ b/docs/adr/0008-oauth-login-goes-public.md
@@ -1,0 +1,44 @@
+# ADR-0008: Browser OAuth is a public login method (ADR-0004's gate deleted)
+
+Date: 2026-08-03 · Status: accepted · Supersedes: ADR-0004
+
+## Context
+
+ADR-0004 shipped browser login dark behind `ADE_OAUTH=1` because the
+platform edge had not deployed OAuth authz to production/eu — a freshly
+minted OIDC access token was rejected with 401 while an API key
+succeeded. The flip-back condition was explicit: delete the gate once
+the platform accepts OIDC tokens. That condition has been met and
+verified against the public environments.
+
+## Decision
+
+The gate is deleted (`ADE_OAUTH`, `auth.py::_oauth_enabled`), exactly
+the flip-back ADR-0004 planned. Flagless `ade auth login` / `ade login`
+now behaves the way a gate-on invocation always did:
+
+- On a terminal: the ADR-0002 method menu (API key first and default,
+  browser OAuth second), with the browser option hidden when it cannot
+  work for the target (no client_id; raw `ADE_ENDPOINT` without a
+  `resource` override).
+- Off a terminal: a piped key still wins (`echo $KEY | ade auth
+  login`); otherwise the login falls to the browser flow, whose own
+  checks diagnose misconfiguration and headless environments.
+
+The `no_credential` remediation branch is retired with the gate — it
+existed only for the gate-closed non-TTY dead end. Its job moves to the
+browser flow's `no_browser` failure, whose JSON payload now names every
+headless spelling (the pipe, `--api-key`, `ADE_API_KEY`), keeping F2
+("headless setup never dead-ends") intact.
+
+The README auth section documents browser login again, per ADR-0004's
+flip-back note.
+
+## Consequences
+
+- ADR-0002's menu decision now applies unconditionally; ADR-0004 is
+  superseded and stays as the record of why launch was API-key-only.
+- `ADE_OAUTH=1` in an environment or script is inert — the behavior it
+  used to opt into is simply the behavior.
+- Stored OAuth sessions keep working as before; the gate never
+  controlled *using* a browser credential, only acquiring one.

--- a/src/ade_cli/auth.py
+++ b/src/ade_cli/auth.py
@@ -243,14 +243,17 @@ def _login_without_key(
     if existing is not None:
         _emit_already(home, resolved, existing, as_json=as_json)
         return
-    if ports.stderr_is_tty():
-        _acquire_interactively(ports, home, resolved, as_json=as_json)
-        return
-    # No terminal to prompt on, but a key piped in is a prompt answered
-    # ahead of time — the headless spelling of the same gesture (F2).
+    # A key piped in is a prompt answered ahead of time — the headless
+    # spelling of the same gesture (F2) — and it wins *before* the menu:
+    # a normal shell pipe (`echo $KEY | ade auth login`) leaves stderr on
+    # the terminal, and the menu would eat the key as its raw selection.
+    # Costless when stdin is a tty or idle (_piped_api_key never blocks).
     piped = _piped_api_key(ports)
     if piped is not None:
         _finish_api_key_login(ports, home, piped, resolved, as_json=as_json)
+        return
+    if ports.stderr_is_tty():
+        _acquire_interactively(ports, home, resolved, as_json=as_json)
         return
     # Straight to the browser flow, whose own checks diagnose
     # misconfiguration authoritatively (client_id, resource, no browser).
@@ -290,8 +293,9 @@ _METHOD_LABELS = (
 def _choose_method(ports: Ports) -> str:
     """API key is first and the default either way, so bare Enter continues
     with it. A real terminal gets the arrow-key pointer (digits jump, Enter
-    confirms); piped stdin, TERM=dumb, and terminals whose raw mode fails
-    get the same list numbered with a typed prompt."""
+    confirms); TERM=dumb and terminals whose raw mode fails get the same
+    list numbered with a typed prompt. (Piped stdin never reaches the
+    menu — a piped line is the key itself, consumed before this.)"""
     if ports.stdin_is_tty() and os.environ.get("TERM") != "dumb":
         typer.echo("How would you like to log in? (↑/↓ and Enter)", err=True)
         try:

--- a/src/ade_cli/auth.py
+++ b/src/ade_cli/auth.py
@@ -19,9 +19,10 @@ key is invalid — the login fails with one canonical message and stores
 nothing, instead of deferring the discovery to the first ``parse``. Any
 other failure (5xx, unreachable network) says nothing about the key, so
 the login reports the platform problem and stores nothing.
-Browser OAuth ships dark at launch (ADR-0004): the platform has not
-deployed OAuth authz to production/eu, so the method menu (ADR-0002) and
-the non-TTY browser path exist only behind ``ADE_OAUTH=1``.
+Browser OAuth is a public login method (ADR-0008 deleted ADR-0004's
+launch gate): a terminal gets the ADR-0002 method menu, and a
+non-interactive run with no piped key falls to the browser flow, whose
+own checks diagnose a headless environment.
 
 ``logout`` de-auths one environment (the resolved target by default;
 ``--all`` clears every environment). ``status`` reports the resolved
@@ -236,9 +237,8 @@ def _login_without_key(
     """No credential flag: *ensure* logged in on the target. A stored
     credential means there is nothing to do (credentials are per
     environment; no selection exists to change). Otherwise acquire one —
-    a terminal prompts (the method menu when OAuth is live, ADR-0004);
-    non-interactive runs get the browser flow only when OAuth is live,
-    and otherwise a remediation naming ``--api-key``."""
+    a terminal prompts (the ADR-0002 method menu); a non-interactive run
+    takes a key piped on stdin, else the browser flow."""
     existing = credentials.stored_credential(home, resolved.environment)
     if existing is not None:
         _emit_already(home, resolved, existing, as_json=as_json)
@@ -252,29 +252,9 @@ def _login_without_key(
     if piped is not None:
         _finish_api_key_login(ports, home, piped, resolved, as_json=as_json)
         return
-    if _oauth_enabled():
-        # Gate open: straight to the browser flow, whose own checks
-        # diagnose misconfiguration authoritatively (client_id, resource).
-        _browser_login(ports, home, resolved, as_json=as_json)
-        return
-    # One message for both modes: the JSON payload is what agents read,
-    # so the remediation must live in it, not only in the human text.
-    human = (
-        f"No stored credential for the {resolved.environment} environment "
-        "and no terminal to prompt on. Pipe the key in "
-        "(`echo $KEY | ade auth login`), pass "
-        "`ade auth login --api-key <key>`, or set ADE_API_KEY."
-    )
-    exit_with(
-        {
-            "error": "no_credential",
-            "environment": resolved.environment,
-            "message": human,
-        },
-        human,
-        as_json=as_json,
-        code=EXIT_FAILED,
-    )
+    # Straight to the browser flow, whose own checks diagnose
+    # misconfiguration authoritatively (client_id, resource, no browser).
+    _browser_login(ports, home, resolved, as_json=as_json)
 
 
 def _acquire_interactively(
@@ -284,15 +264,14 @@ def _acquire_interactively(
     and the default — the method every target supports from day one — and
     browser OAuth is offered only when it can work for the target, so an
     API-key-only rollout (an environment with no client_id yet) collapses
-    to the key prompt alone. With OAuth dark (ADR-0004) the key prompt is
-    simply the method — no menu, no notice. The chosen flow re-checks
-    configuration authoritatively; this gate only keeps dead options out
-    of the menu."""
+    to the key prompt alone. The chosen flow re-checks configuration
+    authoritatively; this check only keeps dead options out of the
+    menu."""
     if _oauth_can_work(home, resolved):
         if _choose_method(ports) == "oauth":
             _browser_login(ports, home, resolved, as_json=as_json)
             return
-    elif _oauth_enabled():
+    else:
         typer.echo(
             "Browser sign-in isn't available for this target; use an API key.",
             err=True,
@@ -331,26 +310,12 @@ def _choose_method(ports: Ports) -> str:
         typer.echo("Choose 1 or 2.", err=True)
 
 
-# Launch gate (ADR-0004): the platform's OAuth authz is not deployed to
-# production/eu, so browser login ships dark — API keys are the only
-# public method. ADE_OAUTH=1 re-enables the browser flow (internal use
-# against environments that accept OIDC tokens). Flip-back is deleting
-# the gate once the platform deploys.
-OAUTH_GATE_ENV = "ADE_OAUTH"
-
-
-def _oauth_enabled() -> bool:
-    return os.environ.get(OAUTH_GATE_ENV) == "1"
-
-
 def _oauth_can_work(home, resolved: ResolvedConfig) -> bool:
-    """Whether the browser flow could succeed for the target: the launch
-    gate is open (ADR-0004), a client_id exists, and — under an
-    ``ADE_ENDPOINT`` override — an explicit ``resource``, since a raw URL
-    has no environment to infer the token audience from. Mirrors
-    _run_browser_flow's checks, which stay authoritative."""
-    if not _oauth_enabled():
-        return False
+    """Whether the browser flow could succeed for the target: a client_id
+    exists, and — under an ``ADE_ENDPOINT`` override — an explicit
+    ``resource``, since a raw URL has no environment to infer the token
+    audience from. Mirrors _run_browser_flow's checks, which stay
+    authoritative."""
     if not oauth.resolve_provider(home, resolved.environment).client_id:
         return False
     if resolved.endpoint_source != "env":
@@ -441,13 +406,17 @@ def _run_browser_flow(
     try:
         return oauth.login(provider, ports)
     except oauth.BrowserUnavailable:
+        # One message for both modes: the JSON payload is what agents
+        # read, so the remediation must live in it, not only in the
+        # human text.
+        human = (
+            "Could not open a browser (headless environment?). Pipe the "
+            "key in (`echo $KEY | ade auth login`), pass "
+            "`ade auth login --api-key <key>`, or set ADE_API_KEY."
+        )
         exit_with(
-            {
-                "error": "no_browser",
-                "message": "Could not open a browser for the OAuth login.",
-            },
-            "Could not open a browser (headless environment?). Use "
-            "`ade auth login --api-key <key>` or set ADE_API_KEY.",
+            {"error": "no_browser", "message": human},
+            human,
             as_json=as_json,
             code=EXIT_FAILED,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ class Cli:
     stderr_tty: bool = False
     stdin_tty: bool = False
     # Per-test env baseline applied after the ambient shield (a test file
-    # opts a whole suite into e.g. the ADR-0004 OAuth gate here).
+    # opts a whole suite into an env var here).
     env_defaults: dict[str, str | None] = field(default_factory=dict)
     # typer's runner keeps stderr separate: progress rendering (#33) is
     # asserted on its own stream (result.stderr), and stdout byte-stability
@@ -142,7 +142,6 @@ class Cli:
             # POST after every invocation. Flush tests opt back in with
             # env={"ADE_TELEMETRY_UPLOAD": None}.
             "ADE_TELEMETRY_UPLOAD": "0",
-            "ADE_OAUTH": None,
             "DO_NOT_TRACK": None,
         }
         merged.update(dict.fromkeys(surface.marker_variables()))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -707,13 +707,17 @@ def test_dumb_terminal_skips_the_arrow_selector(cli):
 
 
 def test_tty_login_menus_and_defaults_to_api_key(cli):
+    # A full terminal whose TERM is dumb: the typed numbered menu (piped
+    # stdin no longer menus — a piped line is the key, per the README).
     cli.stderr_tty = True
+    cli.stdin_tty = True
 
     # Accept the menu default (1 = API key), then give the key — nothing
     # else is asked.
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--json", input="\n" + KEY + "\n"
+        "auth", "login", "--json", input="\n" + KEY + "\n",
+        env={"TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output
@@ -731,10 +735,12 @@ def test_tty_menu_api_key_branch_targets_production_without_asking(cli):
     # path — the menu never follows up with an environment question;
     # --env is how another target is named.
     cli.stderr_tty = True
+    cli.stdin_tty = True
 
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--json", input="1\n" + KEY + "\n"
+        "auth", "login", "--json", input="1\n" + KEY + "\n",
+        env={"TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output
@@ -747,10 +753,12 @@ def test_tty_menu_api_key_branch_targets_production_without_asking(cli):
 
 def test_tty_menu_env_flag_skips_the_environment_prompt(cli):
     cli.stderr_tty = True
+    cli.stdin_tty = True
 
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--env", "eu", "--json", input="1\n" + KEY + "\n"
+        "auth", "login", "--env", "eu", "--json", input="1\n" + KEY + "\n",
+        env={"TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output
@@ -775,10 +783,12 @@ def test_tty_menu_skipped_when_the_target_is_already_authenticated(cli):
 
 def test_tty_menu_reprompts_on_an_unknown_choice(cli):
     cli.stderr_tty = True
+    cli.stdin_tty = True
 
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--json", input="x\n1\n" + KEY + "\n"
+        "auth", "login", "--json", input="x\n1\n" + KEY + "\n",
+        env={"TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output
@@ -812,6 +822,25 @@ def test_headless_login_reads_a_key_piped_on_stdin(cli):
     assert payload["method"] == "api_key"
     assert payload["stored"] is True
     assert KEY not in result.stdout  # the payload masks it
+    creds = json.loads(credentials_file(cli).read_text())["environments"]
+    assert creds["production"]["api_key"] == KEY
+
+
+def test_a_piped_key_wins_over_the_menu_when_stderr_is_a_tty(cli):
+    """`echo $KEY | ade auth login` in a normal shell: stdin is the pipe
+    but stderr stays on the terminal. The piped key must be consumed as
+    the answered prompt, never as the method menu's raw selection — the
+    harness getchar raises on any unscripted read, so this also proves
+    the menu was never consulted."""
+    cli.stderr_tty = True
+    cli.transport.respond(200, {"accepted": 0})
+
+    result = cli.invoke("auth", "login", "--json", input=KEY + "\n")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["method"] == "api_key"
+    assert payload["stored"] is True
     creds = json.loads(credentials_file(cli).read_text())["environments"]
     assert creds["production"]["api_key"] == KEY
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -657,7 +657,7 @@ def test_arrow_menu_enter_alone_continues_with_api_key(cli):
         "auth", "login", "--json",
         input=KEY + "\n",
         keys=["\r"],
-        env={"TERM": "xterm-256color", "ADE_OAUTH": "1"},
+        env={"TERM": "xterm-256color"},
     )
 
     assert result.exit_code == 0, result.output
@@ -679,7 +679,7 @@ def test_arrow_menu_falls_back_to_typed_when_raw_mode_fails(cli):
         "auth", "login", "--json",
         input="1\n" + KEY + "\n",
         keys=[OSError("stdin has no raw mode")],
-        env={"TERM": "xterm-256color", "ADE_OAUTH": "1"},
+        env={"TERM": "xterm-256color"},
     )
 
     assert result.exit_code == 0, result.output
@@ -698,7 +698,7 @@ def test_dumb_terminal_skips_the_arrow_selector(cli):
     result = cli.invoke(
         "auth", "login", "--json",
         input="\n" + KEY + "\n",
-        env={"TERM": "dumb", "ADE_OAUTH": "1"},
+        env={"TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output
@@ -713,8 +713,7 @@ def test_tty_login_menus_and_defaults_to_api_key(cli):
     # else is asked.
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--json", input="\n" + KEY + "\n",
-        env={"ADE_OAUTH": "1"},
+        "auth", "login", "--json", input="\n" + KEY + "\n"
     )
 
     assert result.exit_code == 0, result.output
@@ -735,8 +734,7 @@ def test_tty_menu_api_key_branch_targets_production_without_asking(cli):
 
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--json", input="1\n" + KEY + "\n",
-        env={"ADE_OAUTH": "1"},
+        "auth", "login", "--json", input="1\n" + KEY + "\n"
     )
 
     assert result.exit_code == 0, result.output
@@ -752,8 +750,7 @@ def test_tty_menu_env_flag_skips_the_environment_prompt(cli):
 
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--env", "eu", "--json", input="1\n" + KEY + "\n",
-        env={"ADE_OAUTH": "1"},
+        "auth", "login", "--env", "eu", "--json", input="1\n" + KEY + "\n"
     )
 
     assert result.exit_code == 0, result.output
@@ -781,8 +778,7 @@ def test_tty_menu_reprompts_on_an_unknown_choice(cli):
 
     cli.transport.respond(200, {"accepted": 0})
     result = cli.invoke(
-        "auth", "login", "--json", input="x\n1\n" + KEY + "\n",
-        env={"ADE_OAUTH": "1"},
+        "auth", "login", "--json", input="x\n1\n" + KEY + "\n"
     )
 
     assert result.exit_code == 0, result.output
@@ -791,36 +787,15 @@ def test_tty_menu_reprompts_on_an_unknown_choice(cli):
     assert payload["method"] == "api_key"
 
 
-def test_login_without_flag_prompts_for_key_directly_when_oauth_is_dark(cli):
-    # ADR-0004: with the launch gate closed there is no method menu —
-    # flagless login on a terminal is the hidden key prompt alone, with
-    # no mention of a browser option to advertise.
-    cli.stderr_tty = True
-    cli.stdin_tty = True
-
-    cli.transport.respond(200, {"accepted": 0})
-    result = cli.invoke("auth", "login", "--json", input=KEY + "\n")
-
-    assert result.exit_code == 0, result.output
-    assert "How would you like to log in?" not in result.stderr
-    assert "browser" not in result.stderr.lower()
-    # --json means exactly one JSON object on stdout — parse all of it.
-    payload = json.loads(result.stdout)
-    assert payload["method"] == "api_key"
-    creds = json.loads(credentials_file(cli).read_text())["environments"]
-    assert creds["production"]["api_key"] == KEY
-
-
-def test_non_tty_login_without_key_names_the_api_key_remediation(cli):
-    # ADR-0004: pre-gate, a non-terminal flagless login jumped straight
-    # into the browser flow; dark, it must fail with the --api-key /
-    # ADE_API_KEY remediation instead of starting one.
-    result = cli.invoke("auth", "login", "--json")
+def test_non_tty_login_without_key_falls_to_browser_and_names_the_key_remediation(cli):
+    # ADR-0008: a non-terminal flagless login with no piped key goes
+    # straight into the browser flow; where no browser can open, the
+    # failure names the headless spellings (--api-key / ADE_API_KEY).
+    result = cli.invoke("auth", "login", "--json", browser=lambda _url: False)
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["error"] == "no_credential"
-    assert payload["environment"] == "production"
+    assert payload["error"] == "no_browser"
     # --json emits only the payload, so the remediation must be in it.
     assert "--api-key" in payload["message"]
     assert "ADE_API_KEY" in payload["message"]
@@ -856,12 +831,15 @@ def test_headless_login_honors_the_resolved_environment(cli):
 
 
 def test_headless_login_with_empty_stdin_still_names_the_remediation(cli):
-    """An empty pipe is not a key: the honest error, not a stored blank."""
-    result = cli.invoke("auth", "login", "--json", input="\n")
+    """An empty pipe is not a key: the browser fallback's failure names
+    the headless spellings, and nothing blank is stored."""
+    result = cli.invoke(
+        "auth", "login", "--json", input="\n", browser=lambda _url: False
+    )
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["error"] == "no_credential"
+    assert payload["error"] == "no_browser"
     assert "ADE_API_KEY" in payload["message"]
     assert not credentials_file(cli).exists()
 
@@ -869,7 +847,11 @@ def test_headless_login_with_empty_stdin_still_names_the_remediation(cli):
 def test_headless_login_remediation_names_the_pipe(cli):
     """The escape hatches are discoverable before the failure, but the
     error must still list all of them — including the piped form."""
-    payload = json.loads(cli.invoke("auth", "login", "--json").stdout)
+    payload = json.loads(
+        cli.invoke(
+            "auth", "login", "--json", browser=lambda _url: False
+        ).stdout
+    )
 
     assert "echo $KEY | ade auth login" in payload["message"]
     assert "--api-key" in payload["message"]

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -20,14 +20,6 @@ KEY = "sk-test-0123456789abcd"
 CLIENT_ID = "cli-native-test"
 
 
-@pytest.fixture(autouse=True)
-def _oauth_gate_open(cli):
-    # Every test here exercises the browser flow, which ships dark at
-    # launch (ADR-0004) — run the whole file the way an internal gate-on
-    # invocation would.
-    cli.env_defaults["ADE_OAUTH"] = "1"
-
-
 def _b64url(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
 

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -400,11 +400,17 @@ def test_arrow_menu_escape_aborts_before_any_flow(cli):
 
 
 def test_tty_menu_choice_2_runs_the_browser_flow(cli):
+    # Dumb-terminal shape: the typed menu (piped stdin no longer menus —
+    # a piped line is the key, per the README).
     cli.stderr_tty = True
+    cli.stdin_tty = True
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
 
-    result = cli.invoke("auth", "login", "--json", input="2\n", browser=browser)
+    result = cli.invoke(
+        "auth", "login", "--json", input="2\n", browser=browser,
+        env={"TERM": "dumb"},
+    )
 
     assert result.exit_code == 0, result.output
     assert "How would you like to log in?" in result.stderr
@@ -435,9 +441,12 @@ def test_tty_menu_collapses_to_api_key_when_oauth_is_unconfigured(cli, monkeypat
 
     monkeypatch.delitem(oauth._CLIENT_IDS, "production")
     cli.stderr_tty = True
+    cli.stdin_tty = True
 
     cli.transport.respond(200, {"accepted": 0})  # the verification probe (#117)
-    result = cli.invoke("auth", "login", "--json", input=KEY + "\n")
+    result = cli.invoke(
+        "auth", "login", "--json", input=KEY + "\n", env={"TERM": "dumb"}
+    )
 
     assert result.exit_code == 0, result.output
     assert "How would you like to log in?" not in result.stderr
@@ -452,12 +461,13 @@ def test_tty_menu_hides_browser_under_ade_endpoint_without_a_resource(cli):
     # from, so without a resource override the browser option cannot work
     # and only the key prompt appears.
     cli.stderr_tty = True
+    cli.stdin_tty = True
 
     cli.transport.respond(200, {"accepted": 0})  # the verification probe (#117)
     result = cli.invoke(
         "auth", "login", "--json",
         input=KEY + "\n",
-        env={"ADE_ENDPOINT": "https://custom.example.com"},
+        env={"ADE_ENDPOINT": "https://custom.example.com", "TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output
@@ -482,13 +492,14 @@ def test_tty_menu_offers_browser_under_ade_endpoint_with_a_resource(cli):
         )
     )
     cli.stderr_tty = True
+    cli.stdin_tty = True
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
 
     result = cli.invoke(
         "auth", "login", "--json",
         input="2\n", browser=browser,
-        env={"ADE_ENDPOINT": "https://custom.example.com"},
+        env={"ADE_ENDPOINT": "https://custom.example.com", "TERM": "dumb"},
     )
 
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## What

Deletes ADR-0004's launch gate (`ADE_OAUTH`, `auth.py::_oauth_enabled`) so browser OAuth is a default login method. Flagless `ade auth login` / `ade login` now behaves exactly as a gate-on (`ADE_OAUTH=1`) invocation always did — verified working against the platform.

- **On a terminal**: the ADR-0002 method menu — API key first and default, browser sign-in (OAuth) second. The browser option stays hidden when it cannot work for the target (no client_id; raw `ADE_ENDPOINT` without a `resource` override).
- **Off a terminal**: a piped key still wins (`echo $KEY | ade auth login`); otherwise the login falls to the browser flow, whose own checks diagnose misconfiguration and headless environments.
- The gate-only `no_credential` dead end is retired. Its remediation moves into the browser flow's `no_browser` JSON payload, which now names every headless spelling (the pipe, `--api-key`, `ADE_API_KEY`) — F2 ("headless setup never dead-ends") stays intact, and the remediation lives in the payload agents read.

## Docs

- New [ADR-0008](docs/adr/0008-oauth-login-goes-public.md) records the flip-back; ADR-0004 is marked superseded.
- README auth section documents browser sign-in again (ADR-0004's flip-back note).
- `CONTEXT.md` Provider entry and `CONTRIBUTING.md` ADR examples updated.

## Not changed

No command-surface change (no new flags), so `docs/reference/help.json` / `SKILL.md` are untouched. Stored OAuth sessions were always honored regardless of the gate; that behavior is unchanged.

## Tests

- `tests/test_auth_oauth.py` loses its autouse `ADE_OAUTH=1` fixture — the whole file now runs against default behavior.
- Menu tests in `tests/test_auth.py` drop the env var; the ADR-0004 "dark" tests are replaced by their gate-open counterparts (non-TTY flagless login reaches the browser flow; a browser that can't open fails with `no_browser` naming all three headless remediations).
- `uv run pytest -q`: 575 passed. `uv run ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)