### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ade-cli"
-version = "1.0.0"
+version = "1.0.1"
 description = "CLI for Agentic Document Extraction (ADE) — parse and extract documents with the v2 APIs, backed by a local store"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ade-cli"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bumps `pyproject.toml` and the `uv.lock` entry to **1.0.1**, per the release process in CONTRIBUTING (the Release workflow refuses a tag that doesn't match `pyproject.toml`).

The 1.0.1 release gathers the post-launch fixes and the self-update feature:

- #146 — viewer schema panel renders nullable union types (crop sidebar included)
- #147 — `extract --schema` parses long inline JSON instead of crashing (#143)
- #148 — `history list` stays on-screen with wide schemas; local-time SUBMITTED column (#144)
- #149 — `ade update`: checksum-verified self-update, periodic nudge, unknown-model hint (#138) — *merge before tagging if it should ride this release*
- #151 — browser OAuth as a default login method; piped key wins over the menu

Once merged (and #149 landed): **Actions → Release → "Run workflow"** on `main`, or `git tag v1.0.1 && git push origin v1.0.1`.

The lock change is the minimal ade-cli entry edit — a full `uv lock` from this machine rewrites the file with older-uv formatting churn (no dependency changes), so it was avoided. `uv sync --locked` validates; full suite 591 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)