### PR TITLE
fix: Windows hardening — history clear lock unlink, UTF-8 stdio, atomic-write retry

### DIFF
--- a/src/ade_cli/history.py
+++ b/src/ade_cli/history.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import os
 import shutil
+import time
 from datetime import datetime
+from pathlib import Path
 
 import typer
 
@@ -367,5 +369,39 @@ def _remove_item_dir(jobs: store.JobStore, item_id: str) -> None:
     # racing a mid-write mutator. A guarantee still polling after this
     # survives the sweep — its publication gate (ticket-owns-the-slot) reads
     # the emptied slot and declines to re-persist.
+    #
+    # The lock file itself is deleted only AFTER the lock is released
+    # (#160): holding the lock keeps an open handle on .ticket.lock, and
+    # Windows refuses to unlink a file with an open handle (WinError 32) —
+    # POSIX merely keeps the inode alive, which is why this only crashed
+    # there. Emptied down to its lock file, the directory is a husk (no
+    # ticket, no metadata) that every scan already ignores, so the
+    # in-between state is invisible.
+    item_dir = jobs.item_dir(item_id)
     with jobs.lock(item_id):
-        shutil.rmtree(jobs.item_dir(item_id))
+        for entry in item_dir.iterdir():
+            if entry.name == ".ticket.lock":
+                continue
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+    _remove_husk(item_dir)
+
+
+def _remove_husk(item_dir: Path) -> None:
+    """Delete the emptied item directory and its lock file, with a short
+    retry: a process that was blocked in ``lock()`` still holds its own
+    handle on the lock file for an instant after our release, and Windows
+    refuses the unlink while it does. A husk that outlives the retries is
+    left behind deliberately — it is invisible to listings (no ticket, no
+    metadata) and the next ``history clear --all`` sweeps it."""
+    delay = 0.01
+    for _ in range(10):
+        try:
+            (item_dir / ".ticket.lock").unlink(missing_ok=True)
+            item_dir.rmdir()
+            return
+        except OSError:
+            time.sleep(delay)
+            delay = min(delay * 2, 0.1)

--- a/src/ade_cli/main.py
+++ b/src/ade_cli/main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import typer
 
 from .auth import auth_app, login, logout
@@ -16,6 +18,35 @@ from .ports import Ports
 from .telemetry import LedgerGroup
 from .update import current_version, install_mode, update
 from .view import view
+
+
+def _force_utf8_stdio() -> None:
+    """Reconfigure stdout/stderr to UTF-8 (#161). With no real console
+    attached anywhere in the process chain (headless automation on
+    Windows), Python encodes stdout with the locale codepage — cp1252
+    cannot represent the help topics' box-drawing characters, so the
+    *write itself* raises UnicodeEncodeError. UTF-8 with a replace
+    handler removes the whole failure class regardless of console
+    attachment or system codepage (and makes piped output valid UTF-8);
+    interactive consoles on modern Python already speak UTF-8, so this
+    is a no-op there. Streams without ``reconfigure`` (the test runner's
+    captures, exotic embedders) are left alone."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            encoding = (getattr(stream, "encoding", None) or "").lower()
+            if encoding.replace("-", "").replace("_", "") != "utf8":
+                reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass  # a stream that cannot reconfigure must not kill startup
+
+
+# At import, not per command: the module is only imported to run the CLI
+# (console script, `python -m ade_cli`, and the frozen binary all land
+# here), and help text can print before any callback runs.
+_force_utf8_stdio()
 
 app = typer.Typer(
     name="ade",

--- a/src/ade_cli/store.py
+++ b/src/ade_cli/store.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import threading
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -173,5 +174,31 @@ def write_atomic(path: Path, text: str) -> Path:
         f".{path.name}.tmp-{os.getpid()}-{threading.get_ident()}"
     )
     tmp.write_text(text, encoding="utf-8")
-    os.replace(tmp, path)
+    _replace_with_retry(tmp, path)
     return path
+
+
+# ~0.6s of total patience: enough to outlast another process's momentary
+# open of the destination, short enough that a genuinely locked file
+# (never seen in practice) still errors promptly.
+_REPLACE_ATTEMPTS = 10
+
+
+def _replace_with_retry(tmp: Path, path: Path) -> None:
+    """``os.replace``, retried briefly with backoff on PermissionError
+    (#162). On Windows, MoveFileEx fails with ERROR_ACCESS_DENIED while
+    the destination is momentarily open in another process without
+    share-delete access — and every ade invocation rewrites the same
+    ``history.js``, so two concurrent invocations race on exactly this
+    call. The condition is transient by nature; tens of milliseconds of
+    backoff clears it. POSIX renames never fail this way, so the retry
+    path is Windows-only in practice."""
+    delay = 0.01
+    for _ in range(_REPLACE_ATTEMPTS - 1):
+        try:
+            os.replace(tmp, path)
+            return
+        except PermissionError:
+            time.sleep(delay)
+            delay = min(delay * 2, 0.1)
+    os.replace(tmp, path)

--- a/src/ade_cli/store.py
+++ b/src/ade_cli/store.py
@@ -120,11 +120,32 @@ class JobStore:
     def lock(self, item_id: str) -> Iterator[None]:
         """Interprocess mutex for this item's claim-ticket transitions (and
         live-artifact publication). flock is advisory, which suffices: every
-        mutator is this CLI. Never hold it across network calls."""
+        mutator is this CLI. Never hold it across network calls.
+
+        Acquisition retries when the directory vanishes between the mkdir
+        and the lock-file open — ``history clear`` deletes item dirs (the
+        lock file last, after release; see #160), and that window must
+        surface to a racing mutator as a clean re-acquire on a recreated
+        dir, never a FileNotFoundError crash. Bounded: two live processes
+        cannot ping-pong forever (clear deletes each dir once)."""
         d = self.item_dir(item_id)
-        d.mkdir(parents=True, exist_ok=True)
-        with exclusive(d / ".ticket.lock"):
+        for _ in range(100):
+            d.mkdir(parents=True, exist_ok=True)
+            acquired = exclusive(d / ".ticket.lock")
+            try:
+                acquired.__enter__()
+            except FileNotFoundError:
+                continue
+            break
+        else:  # pragma: no cover - would need 100 perfectly timed clears
+            raise FileNotFoundError(
+                f"could not acquire the item lock for {item_id}: the "
+                "directory kept disappearing during acquisition"
+            )
+        try:
             yield
+        finally:
+            acquired.__exit__(None, None, None)
 
     @contextmanager
     def store_lock(self) -> Iterator[None]:

--- a/tests/test_windows_hardening.py
+++ b/tests/test_windows_hardening.py
@@ -352,3 +352,34 @@ def test_concurrent_history_list_invocations_share_the_store_cleanly(
     # ...and the shared read model came out whole, not torn.
     text = (home / "history.js").read_text(encoding="utf-8")
     assert text.startswith("window.__ADE_HISTORY__ = ")
+
+
+def test_lock_acquisition_retries_when_a_clear_razes_the_directory(
+    tmp_path, monkeypatch
+):
+    """The other side of #160's deletion protocol: a mutator whose
+    ``lock()`` loses the item directory between its mkdir and the
+    lock-file open (a concurrent clear's husk removal) must re-create and
+    re-acquire, never crash with FileNotFoundError."""
+    jobs = jobstore.JobStore(tmp_path / "home")
+    real_exclusive = jobstore.exclusive
+    calls = {"n": 0}
+
+    @contextmanager
+    def racing_exclusive(path):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            # Simulate the clear winning the race: the directory (and so
+            # the lock file's parent) is gone by the time we open.
+            raise FileNotFoundError(2, "No such file or directory", str(path))
+        with real_exclusive(path):
+            yield
+
+    monkeypatch.setattr(jobstore, "exclusive", racing_exclusive)
+
+    entered = False
+    with jobs.lock("cafe0123abcd4567"):
+        entered = True
+        assert (jobs.item_dir("cafe0123abcd4567") / ".ticket.lock").exists()
+    assert entered
+    assert calls["n"] == 3  # two lost races, then a clean acquisition

--- a/tests/test_windows_hardening.py
+++ b/tests/test_windows_hardening.py
@@ -227,3 +227,128 @@ def test_help_topic_survives_a_non_utf8_stdio_in_a_subprocess(tmp_path):
     out = result.stdout.decode("utf-8")
     assert "How the verbs compose" in out
     assert "─" in out  # the diagram's box-drawing characters survived
+
+
+def test_a_husk_directory_is_invisible_and_swept_by_clear_all(cli, document):
+    """The in-between state _remove_item_dir can leave behind on Windows
+    (a directory holding only .ticket.lock, when a waiter's handle
+    outlives the retries) must be harmless: invisible to listings and
+    resolution, and swept by the next clear --all."""
+    item_id = parse_file(cli, document)
+    husk = cli.home / "jobs" / "deadbeef00000000"
+    husk.mkdir(parents=True)
+    (husk / ".ticket.lock").write_bytes(b"")
+
+    listed = cli.invoke("history", "list", "--json")
+    assert [r["job_item_id"] for r in json.loads(listed.stdout)] == [item_id]
+
+    resolve = cli.invoke("history", "clear", "deadbeef", "--json")
+    assert resolve.exit_code == 1  # a husk is not an item; nothing resolves
+    assert json.loads(resolve.stdout)["error"] == "unknown_id"
+
+    swept = cli.invoke("history", "clear", "--all", "--json")
+    assert swept.exit_code == 0, swept.stdout
+    assert json.loads(swept.stdout)["cleared"] == [item_id]  # husks aren't items
+    assert not husk.exists()
+
+
+def test_remove_husk_retries_a_lingering_handle_then_succeeds(
+    cli, document, monkeypatch
+):
+    """A waiter that grabs the lock file between our release and the
+    unlink makes rmdir fail (the file is momentarily back); the husk
+    removal retries instead of crashing, and gives up silently rather
+    than failing the command."""
+    from pathlib import Path
+
+    from ade_cli import history as history_mod
+
+    item_id = parse_file(cli, document)
+    real_rmdir = Path.rmdir
+    failures = {"left": 2}
+
+    def flaky_rmdir(self):
+        if failures["left"] > 0:
+            failures["left"] -= 1
+            raise PermissionError(13, "Access is denied", str(self))
+        return real_rmdir(self)
+
+    monkeypatch.setattr(Path, "rmdir", flaky_rmdir)
+    sleeps: list[float] = []
+    monkeypatch.setattr(history_mod.time, "sleep", sleeps.append)
+
+    result = cli.invoke("history", "clear", item_id, "--json")
+
+    assert result.exit_code == 0, result.stdout
+    assert failures["left"] == 0
+    assert len(sleeps) == 2  # one backoff per denied attempt
+    assert not (cli.home / "jobs" / item_id).exists()
+
+
+def test_startup_survives_a_stream_whose_reconfigure_raises(monkeypatch):
+    """#161's guard is defensive by contract: a stream that *has* a
+    reconfigure but refuses it (an embedder's wrapper) must not kill
+    startup."""
+    from ade_cli import main as main_mod
+
+    class Refusing:
+        encoding = "cp1252"
+
+        def reconfigure(self, **kwargs):
+            raise ValueError("stream cannot be reconfigured")
+
+    monkeypatch.setattr(main_mod.sys, "stdout", Refusing())
+    monkeypatch.setattr(main_mod.sys, "stderr", Refusing())
+
+    main_mod._force_utf8_stdio()  # must simply not raise
+
+
+def test_concurrent_history_list_invocations_share_the_store_cleanly(
+    tmp_path, document
+):
+    """The QA repro shape (#162), cross-platform: N concurrent processes
+    all rewriting the same history.js must every one exit 0 with valid
+    JSON. On Windows this is exactly the race that crashed ~6% of calls;
+    on POSIX it pins the invariant the retry protects."""
+    import concurrent.futures
+
+    home = tmp_path / "shared-home"
+    jobs_dir = home / "jobs" / "cafe0123abcd4567"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "job_item_id": "cafe0123abcd4567",
+                "kind": "parse",
+                "state": "parsed",
+                "source": str(document),
+                "job_id": "job-0001",
+                "params": {"model": "dpt-3-pro-latest", "options": {}, "tier": "priority"},
+            }
+        )
+    )
+    env = {
+        **os.environ,
+        "ADE_HOME": str(home),
+        "ADE_TELEMETRY": "0",
+        "ADE_NO_UPDATE_CHECK": "1",
+    }
+
+    def one_call(_):
+        return subprocess.run(
+            [sys.executable, "-m", "ade_cli", "history", "list", "--json"],
+            capture_output=True,
+            env=env,
+            timeout=120,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(one_call, range(8)))
+
+    for result in results:
+        assert result.returncode == 0, result.stderr.decode(errors="replace")
+        (record,) = json.loads(result.stdout.decode("utf-8"))
+        assert record["job_item_id"] == "cafe0123abcd4567"
+    # ...and the shared read model came out whole, not torn.
+    text = (home / "history.js").read_text(encoding="utf-8")
+    assert text.startswith("window.__ADE_HISTORY__ = ")

--- a/tests/test_windows_hardening.py
+++ b/tests/test_windows_hardening.py
@@ -1,0 +1,229 @@
+"""Windows hardening (#160, #161, #162): three failure classes an
+automated STG suite hit on Windows — the item lock held across the unlink
+of its own lock file, ``os.replace`` racing another process on the shared
+``history.js``, and stdout falling back to a non-UTF-8 locale codec when
+no console is attached. The Windows-only errno paths cannot fire on
+POSIX, so these tests pin the cross-platform *invariants* each fix rests
+on (lock/unlink ordering, replace retries, stdio encoding), plus one
+subprocess repro of the encoding crash itself.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+from ade_cli import store as jobstore
+
+from parse_fixtures import completed_job
+
+KEY = "sk-test-0123456789abcd"
+AUTH_ENV = {"ADE_API_KEY": KEY}
+
+
+@pytest.fixture
+def document(tmp_path):
+    path = tmp_path / "invoice.pdf"
+    path.write_bytes(b"%PDF-1.4 fake invoice bytes")
+    return path
+
+
+def parse_file(cli, document):
+    cli.transport.respond(202, {"job_id": "job-0001"})
+    cli.transport.respond(200, completed_job())
+    result = cli.invoke("parse", "-d", str(document), "--json", env=AUTH_ENV)
+    assert result.exit_code == 0, result.stdout
+    return json.loads(result.stdout)["job_item_id"]
+
+
+# --- #162: write_atomic retries transient replace failures -----------------
+
+
+def test_write_atomic_rides_out_transient_permission_errors(tmp_path, monkeypatch):
+    """On Windows, os.replace fails with ERROR_ACCESS_DENIED while another
+    process momentarily holds the destination open (every invocation
+    rewrites the same history.js). A brief retry absorbs the transient
+    instead of crashing the command."""
+    target = tmp_path / "history.js"
+    real_replace = os.replace
+    failures = {"left": 3}
+
+    def flaky(src, dst, *args, **kwargs):
+        if failures["left"] > 0:
+            failures["left"] -= 1
+            raise PermissionError(13, "Access is denied", str(dst))
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(jobstore.os, "replace", flaky)
+    sleeps: list[float] = []
+    monkeypatch.setattr(jobstore.time, "sleep", sleeps.append)
+
+    jobstore.write_atomic(target, "window.__ADE_HISTORY__ = {};\n")
+
+    assert target.read_text(encoding="utf-8") == "window.__ADE_HISTORY__ = {};\n"
+    assert failures["left"] == 0
+    assert len(sleeps) == 3  # one backoff per transient failure, no spin
+
+
+def test_write_atomic_still_raises_when_the_destination_never_frees(
+    tmp_path, monkeypatch
+):
+    """The retry is patience, not forgiveness: a destination that never
+    frees still surfaces the real error instead of hanging."""
+
+    def denied(src, dst, *args, **kwargs):
+        raise PermissionError(13, "Access is denied", str(dst))
+
+    monkeypatch.setattr(jobstore.os, "replace", denied)
+    monkeypatch.setattr(jobstore.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(PermissionError):
+        jobstore.write_atomic(tmp_path / "history.js", "x")
+
+
+# --- #160: history clear never unlinks the lock file it holds --------------
+
+
+def test_history_clear_deletes_the_lock_file_only_after_releasing_the_lock(
+    cli, document, monkeypatch
+):
+    """Holding the item lock keeps an open handle on .ticket.lock, and
+    Windows refuses to unlink a file with an open handle (WinError 32).
+    The invariant, asserted cross-platform: at the instant the lock is
+    released, the lock file is the one thing still on disk — the husk
+    removal happens strictly after."""
+    item_id = parse_file(cli, document)
+    at_release: dict[str, list[str] | None] = {}
+    real_lock = jobstore.JobStore.lock
+
+    @contextmanager
+    def spying_lock(self, target_id):
+        with real_lock(self, target_id):
+            yield
+        item_dir = self.item_dir(target_id)
+        at_release[target_id] = (
+            sorted(entry.name for entry in item_dir.iterdir())
+            if item_dir.is_dir()
+            else None
+        )
+
+    monkeypatch.setattr(jobstore.JobStore, "lock", spying_lock)
+
+    result = cli.invoke("history", "clear", item_id, "--json")
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["cleared"] == [item_id]
+    assert at_release[item_id] == [".ticket.lock"]
+    assert not (cli.home / "jobs" / item_id).exists()
+
+
+def test_history_clear_all_shares_the_same_unlink_ordering(
+    cli, document, monkeypatch
+):
+    item_id = parse_file(cli, document)
+    at_release: dict[str, list[str] | None] = {}
+    real_lock = jobstore.JobStore.lock
+
+    @contextmanager
+    def spying_lock(self, target_id):
+        with real_lock(self, target_id):
+            yield
+        item_dir = self.item_dir(target_id)
+        at_release[target_id] = (
+            sorted(entry.name for entry in item_dir.iterdir())
+            if item_dir.is_dir()
+            else None
+        )
+
+    monkeypatch.setattr(jobstore.JobStore, "lock", spying_lock)
+
+    result = cli.invoke("history", "clear", "--all", "--json")
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["cleared"] == [item_id]
+    assert at_release[item_id] == [".ticket.lock"]
+    assert not (cli.home / "jobs" / item_id).exists()
+
+
+# --- #161: stdio is UTF-8 whatever the console/codepage situation ----------
+
+
+class _FakeStream:
+    def __init__(self, encoding):
+        self.encoding = encoding
+        self.reconfigured: list[dict] = []
+
+    def reconfigure(self, **kwargs):
+        self.reconfigured.append(kwargs)
+        self.encoding = kwargs.get("encoding", self.encoding)
+
+
+def test_stdio_is_forced_to_utf8_when_the_locale_codec_is_narrower(monkeypatch):
+    """A cp1252 stdout (a console-less Windows process on a non-UTF-8
+    codepage) is reconfigured to UTF-8 with a replace handler, so the help
+    topics' box-drawing characters can never crash the write itself."""
+    from ade_cli import main as main_mod
+
+    out, err = _FakeStream("cp1252"), _FakeStream("cp1252")
+    monkeypatch.setattr(main_mod.sys, "stdout", out)
+    monkeypatch.setattr(main_mod.sys, "stderr", err)
+
+    main_mod._force_utf8_stdio()
+
+    assert out.reconfigured == [{"encoding": "utf-8", "errors": "replace"}]
+    assert err.reconfigured == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_stdio_already_utf8_is_left_alone(monkeypatch):
+    from ade_cli import main as main_mod
+
+    out, err = _FakeStream("utf-8"), _FakeStream("UTF-8")
+    monkeypatch.setattr(main_mod.sys, "stdout", out)
+    monkeypatch.setattr(main_mod.sys, "stderr", err)
+
+    main_mod._force_utf8_stdio()
+
+    assert out.reconfigured == []
+    assert err.reconfigured == []
+
+
+def test_streams_without_reconfigure_are_skipped(monkeypatch):
+    """The test runner's captures (and exotic embedders) expose no
+    reconfigure — startup must not touch or trip over them."""
+    from ade_cli import main as main_mod
+
+    class Bare:
+        encoding = "cp1252"
+
+    monkeypatch.setattr(main_mod.sys, "stdout", Bare())
+    monkeypatch.setattr(main_mod.sys, "stderr", Bare())
+
+    main_mod._force_utf8_stdio()  # must simply not raise
+
+
+def test_help_topic_survives_a_non_utf8_stdio_in_a_subprocess(tmp_path):
+    """End-to-end repro of the QA failure mode: force the interpreter to
+    pick a cp1252 stdout codec (what a console-less process on a cp1252
+    Windows machine gets) and print the topic carrying the box-drawing
+    pipeline diagram. Before the fix the write itself raised
+    UnicodeEncodeError; with it, startup re-encodes stdout as UTF-8."""
+    env = {
+        **os.environ,
+        "PYTHONIOENCODING": "cp1252",
+        "ADE_HOME": str(tmp_path),
+        "ADE_TELEMETRY": "0",
+        "ADE_NO_UPDATE_CHECK": "1",
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "ade_cli", "help", "workflow"],
+        capture_output=True,
+        env=env,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr.decode(errors="replace")
+    out = result.stdout.decode("utf-8")
+    assert "How the verbs compose" in out
+    assert "─" in out  # the diagram's box-drawing characters survived


### PR DESCRIPTION
Fixes the three Windows-specific crashes reported by the automated STG test pass (Asana: `history clear` WinError 32, `help <topic>` UnicodeEncodeError, `history list`/`view` WinError 5 under concurrency).

## What changed

### 1. `history clear` — PermissionError [WinError 32] (closes #160)
`_remove_item_dir` held the item lock (an open handle on `<item>/.ticket.lock`) while `shutil.rmtree` unlinked that very file — POSIX allows unlinking an open file, Windows does not. Now the directory is emptied down to its lock file **under** the lock (the in-between state is a husk — no ticket, no metadata — which every scan already ignores), and the lock file + empty directory are removed **after** release, with a short retry to outlast a waiter's lingering handle. A husk that survives the retries stays invisible to listings and is swept by the next `clear --all`. Deterministic on Windows per the report; the ordering invariant is pinned cross-platform by tests (at the instant the lock is released, `.ticket.lock` is the only thing left on disk).

### 2. `help <topic>` — UnicodeEncodeError with no console attached (closes #161)
The help topics carry box-drawing/arrow characters; with no real Win32 console handle anywhere in the process chain, Python encodes stdout with the locale codepage (cp1252 on the reporting machine) and the write itself raises. Per the ticket's suggested fix, startup now reconfigures stdout/stderr to UTF-8 with `errors="replace"` whenever they aren't already UTF-8 — a no-op on interactive consoles (already UTF-8 on modern Python) and on streams without `reconfigure` (test captures). Also makes piped `--json` output valid UTF-8 on such machines. Includes a subprocess end-to-end repro (`PYTHONIOENCODING=cp1252` + `ade help workflow`) that fails without the fix and passes with it — verified both ways.

### 3. `history list`/`view` — PermissionError [WinError 5] under concurrency (closes #162)
Every invocation rewrites the shared `history.js` via `write_atomic`'s `os.replace`; on Windows, MoveFileEx fails with ERROR_ACCESS_DENIED while the destination is momentarily open in another process (reproduced at ~6% under 12-way concurrency in the report, zero network involved). `os.replace` is now retried briefly with backoff (~0.6 s total patience) on `PermissionError` — the standard mitigation — while a destination that never frees still raises.

## Tests
- 8 new tests in `tests/test_windows_hardening.py`: replace-retry success and give-up paths, lock-release-before-unlink ordering for both `clear JOB_ID` and `clear --all`, stdio reconfigure matrix (cp1252 → UTF-8, UTF-8 untouched, no-reconfigure streams skipped), and the subprocess encoding repro.
- Full suite: 620 passed; `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)