### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ade-cli"
-version = "1.0.1"
+version = "1.0.2"
 description = "CLI for Agentic Document Extraction (ADE) — parse and extract documents with the v2 APIs, backed by a local store"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ade-cli"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bump `pyproject.toml` and `uv.lock` to 1.0.2, picking up:

- #159 — QA bug sweep: server-side "job" → "run" rename (`run_id` payloads, `JOB_ITEM_ID` metavars), empty-schema gate before any billable call, `--json` honored on Click validation errors, `crop -o <dir>` for single crops, one `crop --json` shape, and stale marking for extractions after `parse --force`.
- #163 — Windows hardening: `history clear` lock-file unlink ordering (WinError 32), UTF-8 stdio for console-less processes (UnicodeEncodeError), and atomic-write retry under concurrency (WinError 5).

Note for release notes: #159 renames `job_id` → `run_id` in `--json` payloads and changes `crop --json` to always emit `{count, directory, crops[]}` — breaking for scripts consuming the old keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)