### PR TITLE
fix: v1.0.2 QA sweep — pending item id, Windows piped login, URL preview messaging, extract hint, WinError 87, path backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ source path × content × params` — one flat folder under
 `parse.json` (raw response), `parse.md` (markdown with its doc_id trailer),
 `elements.json` (flat elements projection, recomputable from `parse.json`),
 `meta.json` (provenance + params + identity), `job.json` (claim ticket).
+(Inside these files the server-side run id is spelled `job_id` — the
+wire's name for the same value `--json` payloads report as `run_id`;
+neither is the job item id.)
 `parse` is a guarantee: re-running the exact same invocation is served from
 disk with zero API calls (`--force` re-parses in place); changed params —
 or a moved/edited file — mint a *sibling* job item, so variants coexist and

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ loads the rest on demand from sidecar files rendered into the store.
 The read model over the store — zero API calls; states derive from tickets
 and artifacts on disk. Listings show the newest 100 submissions, newest
 first (the run you just did leads, matching the viewer sidebar) — a
-capped listing says so in its last line; `--limit N` adjusts the cap,
+capped listing says so in its first line; `--limit N` adjusts the cap,
 `--all` lifts it, and `--asc` presents the same items oldest-first, in
 `--json` too. Extract items
 referencing a parse render as indented

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ open it exits immediately, naming all three paths.
 |---|---|
 | `ade parse -d invoice.pdf` | ensure parsed; artifacts land in `~/.ade` |
 | `ade parse --document-url https://…/doc.pdf` | server fetches the URL |
+| `ade parse --document-url https://… --keep-copy` | also store the document bytes locally, so page previews and crops render |
 | `ade parse -d doc.pdf --tier standard --wait 0` | cheap lane, submit-and-return |
 | `ade parse -d doc.pdf --env eu` | run in the EU region (or `export ADE_ENV=eu`) |
 | `ade parse -d doc.pdf --include markdown --json` | carry the markdown in the payload |
@@ -199,6 +200,12 @@ On a terminal, `view` opens the viewer in your browser by default
 (`--no-open` suppresses it); `--json` runs and piped output never
 launch a browser — the artifact path is in the output either way.
 Without a JOB_ITEM_ID, `view` targets the latest viewable job item.
+URL-parsed items have no local document bytes, so page previews can't
+render until you fetch them: `ade view <id> --download` attaches a copy
+of the document to the job item (plain HTTP, no API credits — but note
+pre-signed URLs expire, so `parse --keep-copy` at parse time is the
+reliable way), after which previews and crops render from it with an
+"unverified against the parsed run" caveat.
 
 Every job item gets a **self-contained `view.html`**: page images with
 bounding-box overlays beside the parsed markdown (or extraction JSON),

--- a/README.md
+++ b/README.md
@@ -233,13 +233,17 @@ loads the rest on demand from sidecar files rendered into the store.
 | command | what it does |
 |---|---|
 | `ade history` | defaults to `ade history list` |
-| `ade history list` | one row per job item: id, kind, state, params, source |
+| `ade history list` | one row per job item: id, kind, state, params, source — newest first |
+| `ade history list --asc` | the same listing, oldest first |
 | `ade history list --json` | full records (params verbatim, timestamps, linkage) |
 | `ade history clear JOB_ITEM_ID` | delete an item; clearing a parse cascades to its extracts |
 | `ade history clear --all` | delete every stored job item |
 
 The read model over the store — zero API calls; states derive from tickets
-and artifacts on disk. Extract items referencing a parse render as indented
+and artifacts on disk. Listings are ordered newest submission first (the
+run you just did leads, matching the viewer sidebar); `--asc` restores
+the oldest-first chronological read, in `--json` too. Extract items
+referencing a parse render as indented
 child rows beneath it; an extraction whose parse was re-run in place with
 `--force` is marked **stale** (listing annotation, `"stale": true` in
 `--json`, and an amber mark with a hover tooltip in the viewer sidebar) —

--- a/README.md
+++ b/README.md
@@ -233,16 +233,19 @@ loads the rest on demand from sidecar files rendered into the store.
 | command | what it does |
 |---|---|
 | `ade history` | defaults to `ade history list` |
-| `ade history list` | one row per job item: id, kind, state, params, source — newest first |
-| `ade history list --asc` | the same listing, oldest first |
+| `ade history list` | one row per job item: id, kind, state, params, source — newest 100, newest first |
+| `ade history list --asc` | the same newest items, oldest first |
+| `ade history list --all` | every stored job item, no cap (`--limit N` picks another cap) |
 | `ade history list --json` | full records (params verbatim, timestamps, linkage) |
 | `ade history clear JOB_ITEM_ID` | delete an item; clearing a parse cascades to its extracts |
 | `ade history clear --all` | delete every stored job item |
 
 The read model over the store — zero API calls; states derive from tickets
-and artifacts on disk. Listings are ordered newest submission first (the
-run you just did leads, matching the viewer sidebar); `--asc` restores
-the oldest-first chronological read, in `--json` too. Extract items
+and artifacts on disk. Listings show the newest 100 submissions, newest
+first (the run you just did leads, matching the viewer sidebar) — a
+capped listing says so in its last line; `--limit N` adjusts the cap,
+`--all` lifts it, and `--asc` presents the same items oldest-first, in
+`--json` too. Extract items
 referencing a parse render as indented
 child rows beneath it; an extraction whose parse was re-run in place with
 `--force` is marked **stale** (listing annotation, `"stale": true` in

--- a/SKILL.md
+++ b/SKILL.md
@@ -179,3 +179,8 @@ clearing a parse item cascades to the extractions referencing it.
 - **`--markdown` extractions have no page evidence** (there is no parse
   to join against) — evidence degrades to spans-only, and `view`
   renders the markdown pane alone.
+- **URL parses have no local bytes**, so `view`/`crop` cannot render
+  page imagery until you attach a copy: `parse --document-url …
+  --keep-copy` at parse time (reliable — pre-signed URLs expire), or
+  `ade view <id> --download` after the fact. Markdown, elements, and
+  extractions work either way.

--- a/SKILL.md
+++ b/SKILL.md
@@ -161,6 +161,11 @@ the summaries print each item's store path.
 - `extract.json` — raw extraction result with per-field spans
 - `evidence.json` — the field→box join (element ids, pages, boxes)
 
+One vocabulary note when reading these files: on-disk records
+(`meta.json`, `job.json`, `parse/ref.json`) spell the server-side run id
+as `job_id` — the wire contract's name for the same value `--json`
+payloads report as `run_id`. Neither is ever the job item id.
+
 Prefer `find` over loading `elements.json` into context: it returns
 joined records, not lines. `history clear JOB_ITEM_ID` deletes an item;
 clearing a parse item cascades to the extractions referencing it.

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -749,10 +749,18 @@
     },
     {
       "name": "history list",
-      "usage": "ade history list [--json]",
-      "summary": "List stored job items: id, kind, state, env, params, source. Extract\nitems referencing a parse item indent beneath it. Bare `ade history`\ndefaults to this command.",
+      "usage": "ade history list [options] [--json]",
+      "summary": "List stored job items: id, kind, state, env, params, source \u2014\nnewest submission first (--asc for oldest first). Extract items\nreferencing a parse item indent beneath it. Bare `ade history`\ndefaults to this command.",
       "arguments": [],
-      "flags": [],
+      "flags": [
+        {
+          "flags": "--asc",
+          "metavar": null,
+          "required": false,
+          "default": null,
+          "help": "Oldest submission first (the pre-1.0.3 order). The listing defaults to newest first \u2014 the run you just did leads, matching the viewer sidebar."
+        }
+      ],
       "supports_json": true,
       "result": {
         "shape": "array",
@@ -793,7 +801,8 @@
             "key": "created_at / completed_at",
             "what": "epoch seconds (null when unknown)"
           }
-        ]
+        ],
+        "note": "Ordered newest submission first (timestamp-less items last), matching the viewer sidebar; --asc restores oldest-first. The --json array follows the same order."
       },
       "band": "local read models"
     },

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -468,6 +468,13 @@
           "help": "Re-parse even if already parsed, or abandon an unreadable job for a fresh one (bills a new parse)."
         },
         {
+          "flags": "--keep-copy",
+          "metavar": null,
+          "required": false,
+          "default": null,
+          "help": "--document-url only: also download the document into the job item (plain HTTP, no API credits) so page previews and crops render locally \u2014 fetched now, while the URL (often pre-signed) still works. Without it, URL parses have no local bytes and the viewer explains how to fetch them later (`ade view <id> --download`)."
+        },
+        {
           "flags": "--include",
           "metavar": "markdown|elements",
           "required": false,
@@ -545,6 +552,14 @@
           {
             "key": "elements",
             "what": "the flat projection \u2014 only with --include elements"
+          },
+          {
+            "key": "kept_copy",
+            "what": "with --keep-copy: whether the URL document's copy was stored in the job item"
+          },
+          {
+            "key": "keep_copy_error",
+            "what": "with --keep-copy: why the copy could not be stored (the parse itself still succeeded)"
           }
         ]
       },
@@ -961,6 +976,13 @@
           "help": "Pages to embed images for, 1-indexed, e.g. '1,3-5'."
         },
         {
+          "flags": "--download",
+          "metavar": null,
+          "required": false,
+          "default": null,
+          "help": "URL-parsed items: fetch the document from its recorded URL into the job item and render page previews from that copy \u2014 the parse itself never gives the CLI the bytes (#169). Plain HTTP, no API credits; the copy is unverified against the parsed run. Also works on an extract item id (fetches into its referenced parse item)."
+        },
+        {
           "flags": "--no-sidebar-sync",
           "metavar": null,
           "required": false,
@@ -1013,6 +1035,10 @@
           {
             "key": "note",
             "what": "why the render weakened, when it did (else null)"
+          },
+          {
+            "key": "downloaded",
+            "what": "with --download: true when this run fetched the URL document into the job item (false: already attached)"
           },
           {
             "key": "deep_link",
@@ -1278,6 +1304,10 @@
       {
         "path": "  markdown.md",
         "what": "bring-your-own-markdown extract items: the input markdown, copied in (spans index exactly these bytes)"
+      },
+      {
+        "path": "  document.<ext>",
+        "what": "URL parses: the attached document copy (`parse --keep-copy` / `view --download`) page previews and crops render from \u2014 unverified against the parsed run"
       },
       {
         "path": "  view.html / crops/",

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -816,7 +816,7 @@
             "what": "epoch seconds (null when unknown)"
           }
         ],
-        "note": "Ordered newest submission first (timestamp-less items last), matching the viewer sidebar; --asc restores oldest-first. Capped at the newest 100 items by default \u2014 --limit N adjusts, --all lifts the cap, and a capped run says so on stderr. The --json array follows the same order and cap."
+        "note": "Ordered newest submission first (timestamp-less items last), matching the viewer sidebar; --asc restores oldest-first. Capped at the newest 100 items by default \u2014 --limit N adjusts, --all lifts the cap, and a capped run says so up front (the first line of the listing; on stderr for --json). The --json array follows the same order and cap."
       },
       "band": "local read models"
     },

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "job item ids",
-      "rule": "Store commands take a job item id or an unambiguous prefix. Discover ids with `history list`; ambiguous or unknown ids error with candidates listed."
+      "rule": "Store commands take a job item id or an unambiguous prefix. Discover ids with `history list`; ambiguous or unknown ids error with candidates listed. Distinct from the server-side run id: --json payloads report that as run_id, and on-disk records spell the same value job_id (the wire's name) \u2014 neither is ever a job item id."
     },
     {
       "name": "guarantees",
@@ -1264,6 +1264,7 @@
   ],
   "store": {
     "home": "~/.ade (ADE_HOME overrides)",
+    "note": "On-disk records (meta.json, job.json, parse/ref.json) spell the server-side run id as job_id \u2014 the wire contract's name for the same value --json payloads report as run_id. Neither is the job item id (the jobs/<id>/ folder name).",
     "layout": [
       {
         "path": "~/.ade/config.json",
@@ -1283,7 +1284,7 @@
       },
       {
         "path": "  meta.json",
-        "what": "commit record: kind, source, identity, params, state, timestamps, artifact index"
+        "what": "commit record: kind, source, identity, params, state, timestamps, artifact index. Its job_id field is the server-side run id (= run_id in --json payloads), never the job item id"
       },
       {
         "path": "  job.json",

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -750,7 +750,7 @@
     {
       "name": "history list",
       "usage": "ade history list [options] [--json]",
-      "summary": "List stored job items: id, kind, state, env, params, source \u2014\nnewest submission first (--asc for oldest first). Extract items\nreferencing a parse item indent beneath it. Bare `ade history`\ndefaults to this command.",
+      "summary": "List stored job items: id, kind, state, env, params, source \u2014\nthe newest 100 submissions first (--limit/--all adjust, --asc for\noldest first). Extract items referencing a parse item indent\nbeneath it. Bare `ade history` defaults to this command.",
       "arguments": [],
       "flags": [
         {
@@ -759,6 +759,20 @@
           "required": false,
           "default": null,
           "help": "Oldest submission first (the pre-1.0.3 order). The listing defaults to newest first \u2014 the run you just did leads, matching the viewer sidebar."
+        },
+        {
+          "flags": "--limit",
+          "metavar": "INTEGER",
+          "required": false,
+          "default": 100,
+          "help": "Keep only the newest N items (default 100), whatever the order; --all lifts the cap."
+        },
+        {
+          "flags": "--all",
+          "metavar": null,
+          "required": false,
+          "default": null,
+          "help": "List every stored job item \u2014 no limit."
         }
       ],
       "supports_json": true,
@@ -802,7 +816,7 @@
             "what": "epoch seconds (null when unknown)"
           }
         ],
-        "note": "Ordered newest submission first (timestamp-less items last), matching the viewer sidebar; --asc restores oldest-first. The --json array follows the same order."
+        "note": "Ordered newest submission first (timestamp-less items last), matching the viewer sidebar; --asc restores oldest-first. Capped at the newest 100 items by default \u2014 --limit N adjusts, --all lifts the cap, and a capped run says so on stderr. The --json array follows the same order and cap."
       },
       "band": "local read models"
     },

--- a/src/ade_cli/attach.py
+++ b/src/ade_cli/attach.py
@@ -80,16 +80,33 @@ def renderable_source(jobs: JobStore, item_id: str, meta: dict | None) -> str | 
     return source
 
 
+# The full story behind the caveat — the viewer shows it on hover (like
+# the stale badge); the CLI surfaces carry only the short, actionable
+# form below.
+CAVEAT_DETAIL = (
+    "This item was parsed from a URL: the server fetched and read the "
+    "original document, and the CLI never received those bytes. The copy "
+    "behind these page images was downloaded separately — almost "
+    "certainly identical, but there is nothing to verify it against. "
+    "Markdown, elements, and extractions come straight from the parse "
+    "and are unaffected either way. If boxes ever look misaligned with "
+    "a page image, the remote document likely changed since the parse — "
+    "re-parse the downloaded file locally (ade parse -d <file>) for a "
+    "fully verifiable item."
+)
+
+
 def caveat(jobs: JobStore, item_id: str, meta: dict | None) -> str | None:
-    """The honesty note renders from an attached copy must carry: the CLI
-    never saw the bytes the server parsed, so the copy cannot be verified
-    against that generation."""
+    """The short, actionable form of the attached-copy caveat, for the
+    surfaces with no hover (the CLI note line, crop warnings). Calm by
+    design: the copy is almost always right — the note says what to do
+    in the one case it isn't."""
     if not is_url_source(meta) or attached_file(jobs, item_id, meta) is None:
         return None
     return (
-        "page imagery renders from the item's downloaded copy of the URL "
-        "(the CLI never saw the bytes the server parsed, so the copy is "
-        "unverified against that run)"
+        "page imagery renders from the item's downloaded copy of the URL; "
+        "if boxes ever look misaligned, re-parse the downloaded file "
+        "locally (ade parse -d <file>)"
     )
 
 

--- a/src/ade_cli/attach.py
+++ b/src/ade_cli/attach.py
@@ -20,6 +20,7 @@ verifiable against the parsed generation: renders from it carry the
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -123,44 +124,66 @@ def download(
     pre-signed URLs expire, so a late fetch failing is the expected
     failure mode, not a surprise."""
     url = meta.get("source") or ""
+    name = copy_name(url)
+    target = jobs.item_dir(item_id) / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{name}.tmp-{os.getpid()}")
+    digest = hashlib.sha256()
+    received = 0
+    # Streamed to disk, never buffered whole: the size cap must reject a
+    # wrong URL as soon as it is exceeded (or up front, when the server
+    # declares Content-Length), not after the entire body sat in memory.
     try:
         with httpx.Client(
             transport=transport, follow_redirects=True, timeout=60.0
         ) as client:
-            response = client.get(url)
+            with client.stream("GET", url) as response:
+                if response.status_code != 200:
+                    raise AttachError(
+                        "download_failed",
+                        f"{url} answered HTTP {response.status_code} — "
+                        "pre-signed URLs expire, so the link that fed this "
+                        "parse may no longer serve the document. Download "
+                        "it by other means and parse the local file "
+                        "(ade parse -d <file>), or re-parse with a fresh "
+                        "URL and --keep-copy.",
+                    )
+                declared = response.headers.get("content-length", "")
+                if declared.isdigit() and int(declared) > MAX_COPY_BYTES:
+                    raise AttachError(
+                        "download_failed",
+                        f"{url} declares {declared} bytes — past the "
+                        f"{MAX_COPY_BYTES}-byte attach cap; parse the local "
+                        "file instead (ade parse -d <file>).",
+                    )
+                with tmp.open("wb") as sink:
+                    for chunk in response.iter_bytes():
+                        received += len(chunk)
+                        if received > MAX_COPY_BYTES:
+                            raise AttachError(
+                                "download_failed",
+                                f"{url} exceeded the {MAX_COPY_BYTES}-byte "
+                                "attach cap mid-download; parse the local "
+                                "file instead (ade parse -d <file>).",
+                            )
+                        digest.update(chunk)
+                        sink.write(chunk)
     except httpx.HTTPError as error:
+        tmp.unlink(missing_ok=True)
         raise AttachError(
             "download_failed",
             f"could not fetch {url}: {type(error).__name__}: {error}. "
             "Download the document by other means and parse the local "
             "file (ade parse -d <file>).",
         ) from error
-    if response.status_code != 200:
-        raise AttachError(
-            "download_failed",
-            f"{url} answered HTTP {response.status_code} — pre-signed URLs "
-            "expire, so the link that fed this parse may no longer serve "
-            "the document. Download it by other means and parse the local "
-            "file (ade parse -d <file>), or re-parse with a fresh URL and "
-            "--keep-copy.",
-        )
-    content = response.content
-    if not content:
+    except AttachError:
+        tmp.unlink(missing_ok=True)
+        raise
+    if received == 0:
+        tmp.unlink(missing_ok=True)
         raise AttachError(
             "download_failed", f"{url} answered an empty body; nothing to attach."
         )
-    if len(content) > MAX_COPY_BYTES:
-        raise AttachError(
-            "download_failed",
-            f"{url} answered {len(content)} bytes — past the "
-            f"{MAX_COPY_BYTES}-byte attach cap; parse the local file instead "
-            "(ade parse -d <file>).",
-        )
-    name = copy_name(url)
-    target = jobs.item_dir(item_id) / name
-    target.parent.mkdir(parents=True, exist_ok=True)
-    tmp = target.with_name(f".{name}.tmp-{id(content)}")
-    tmp.write_bytes(content)
     replace_with_retry(tmp, target)
     # Record on the commit record under the item lock — a read-modify-write
     # against whatever generation currently owns meta.json.
@@ -169,9 +192,9 @@ def download(
         current.update(
             {
                 "attached_source": name,
-                "attached_sha256": hashlib.sha256(content).hexdigest(),
+                "attached_sha256": digest.hexdigest(),
                 "attached_at": now,
             }
         )
         jobs.write_json(item_id, "meta.json", current)
-    return name, len(content)
+    return name, received

--- a/src/ade_cli/attach.py
+++ b/src/ade_cli/attach.py
@@ -1,0 +1,160 @@
+"""Attached document copies for URL-parsed job items (#169).
+
+``parse --document-url`` never hands the CLI the document bytes — the
+server fetches the URL — so page previews and crops have nothing local
+to render from. An *attached copy* closes that gap on explicit consent:
+``parse --keep-copy`` downloads the document at parse time (while the
+URL — often pre-signed — still works), and ``view --download`` fetches
+it after the fact. The copy lives inside the job item
+(``jobs/<id>/document.<ext>``) and is recorded on meta.json as auxiliary
+metadata: the recorded ``source`` stays the URL (provenance truth) and
+the item id never moves. The raster layer falls back to the copy via
+``renderable_source``.
+
+The CLI still never fetches a URL without one of these explicit flags —
+and because it never saw the original bytes, an attached copy is not
+verifiable against the parsed generation: renders from it carry the
+``caveat`` note rather than posing as ground truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+
+from .store import JobStore, replace_with_retry
+
+# Extensions preserved on the copy's filename — a display nicety only;
+# the renderer sniffs bytes, never the suffix.
+_KNOWN_SUFFIXES = {".pdf", ".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"}
+
+# A copy exists to be rastered locally; past this it is likelier a wrong
+# URL than a document.
+MAX_COPY_BYTES = 512 * 1024 * 1024
+
+_URL_PREFIXES = ("http://", "https://")
+
+
+class AttachError(Exception):
+    """A copy that could not be attached; ``kind`` is the machine code."""
+
+    def __init__(self, kind: str, message: str):
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+def is_url_source(meta: dict | None) -> bool:
+    source = (meta or {}).get("source") or ""
+    return source.startswith(_URL_PREFIXES)
+
+
+def copy_name(url: str) -> str:
+    suffix = Path(urlparse(url).path).suffix.lower()
+    return f"document{suffix if suffix in _KNOWN_SUFFIXES else ''}"
+
+
+def attached_file(jobs: JobStore, item_id: str, meta: dict | None) -> Path | None:
+    """The attached copy's path, when one is recorded AND still on disk —
+    a manually deleted copy degrades back to the URL messaging."""
+    name = (meta or {}).get("attached_source")
+    if not name:
+        return None
+    path = jobs.item_dir(item_id) / name
+    return path if path.is_file() else None
+
+
+def renderable_source(jobs: JobStore, item_id: str, meta: dict | None) -> str | None:
+    """What page imagery renders from: the recorded source verbatim for
+    local items (missing files keep their honest notes), the attached
+    copy for URL items that have one, else the URL itself (whose note
+    names the --download remediation)."""
+    source = (meta or {}).get("source")
+    if source and source.startswith(_URL_PREFIXES):
+        attached = attached_file(jobs, item_id, meta)
+        if attached is not None:
+            return str(attached)
+    return source
+
+
+def caveat(jobs: JobStore, item_id: str, meta: dict | None) -> str | None:
+    """The honesty note renders from an attached copy must carry: the CLI
+    never saw the bytes the server parsed, so the copy cannot be verified
+    against that generation."""
+    if not is_url_source(meta) or attached_file(jobs, item_id, meta) is None:
+        return None
+    return (
+        "page imagery renders from the item's downloaded copy of the URL "
+        "(the CLI never saw the bytes the server parsed, so the copy is "
+        "unverified against that run)"
+    )
+
+
+def download(
+    jobs: JobStore,
+    item_id: str,
+    meta: dict,
+    *,
+    transport: httpx.BaseTransport,
+    now: float,
+) -> tuple[str, int]:
+    """Fetch the item's URL source and attach the copy; returns
+    ``(filename, bytes)``. Raises AttachError with the remediation —
+    pre-signed URLs expire, so a late fetch failing is the expected
+    failure mode, not a surprise."""
+    url = meta.get("source") or ""
+    try:
+        with httpx.Client(
+            transport=transport, follow_redirects=True, timeout=60.0
+        ) as client:
+            response = client.get(url)
+    except httpx.HTTPError as error:
+        raise AttachError(
+            "download_failed",
+            f"could not fetch {url}: {type(error).__name__}: {error}. "
+            "Download the document by other means and parse the local "
+            "file (ade parse -d <file>).",
+        ) from error
+    if response.status_code != 200:
+        raise AttachError(
+            "download_failed",
+            f"{url} answered HTTP {response.status_code} — pre-signed URLs "
+            "expire, so the link that fed this parse may no longer serve "
+            "the document. Download it by other means and parse the local "
+            "file (ade parse -d <file>), or re-parse with a fresh URL and "
+            "--keep-copy.",
+        )
+    content = response.content
+    if not content:
+        raise AttachError(
+            "download_failed", f"{url} answered an empty body; nothing to attach."
+        )
+    if len(content) > MAX_COPY_BYTES:
+        raise AttachError(
+            "download_failed",
+            f"{url} answered {len(content)} bytes — past the "
+            f"{MAX_COPY_BYTES}-byte attach cap; parse the local file instead "
+            "(ade parse -d <file>).",
+        )
+    name = copy_name(url)
+    target = jobs.item_dir(item_id) / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{name}.tmp-{id(content)}")
+    tmp.write_bytes(content)
+    replace_with_retry(tmp, target)
+    # Record on the commit record under the item lock — a read-modify-write
+    # against whatever generation currently owns meta.json.
+    with jobs.lock(item_id):
+        current = jobs.read_json(item_id, "meta.json") or {}
+        current.update(
+            {
+                "attached_source": name,
+                "attached_sha256": hashlib.sha256(content).hexdigest(),
+                "attached_at": now,
+            }
+        )
+        jobs.write_json(item_id, "meta.json", current)
+    return name, len(content)

--- a/src/ade_cli/auth.py
+++ b/src/ade_cli/auth.py
@@ -32,13 +32,12 @@ target plus every other environment holding a credential.
 from __future__ import annotations
 
 import os
-import select
 import sys
 
 import httpx
 import typer
 
-from . import credentials, gateway, oauth, term
+from . import credentials, filelock, gateway, oauth, term
 from .config import (
     ENVIRONMENTS,
     ResolvedConfig,
@@ -105,15 +104,13 @@ def _prompt_api_key(ports: Ports) -> str:
 # paid only on the path that would otherwise exit with an error anyway.
 _PIPED_KEY_TIMEOUT = 0.25
 
-
 def _piped_api_key(ports: Ports) -> str | None:
     """A key piped on stdin (``echo $KEY | ade auth login``), or None.
 
-    Never blocks on an idle pipe: stdin is read only once select says a
-    line is already there, so a harness that leaves stdin open but silent
-    gets the remediation immediately instead of a hang. Where select
-    cannot answer for the stream (Windows console handles) that is a No —
-    those callers still have ``--api-key`` and ``ADE_API_KEY``.
+    Never blocks on an idle pipe: stdin is read only once the platform
+    probe (select on POSIX, PeekNamedPipe on Windows — #168) says a line
+    is already there, so a harness that leaves stdin open but silent gets
+    the remediation immediately instead of a hang.
     """
     if ports.stdin_is_tty():
         return None
@@ -123,12 +120,10 @@ def _piped_api_key(ports: Ports) -> str | None:
         # Not a real OS stream (an in-process runner's buffer): readable
         # by construction, and reading it cannot block on a writer.
         fileno = None
-    if fileno is not None:
-        try:
-            if not select.select([fileno], [], [], _PIPED_KEY_TIMEOUT)[0]:
-                return None
-        except OSError:
-            return None
+    if fileno is not None and not filelock.stdin_ready(
+        fileno, timeout=_PIPED_KEY_TIMEOUT
+    ):
+        return None
     return sys.stdin.readline().strip() or None
 
 

--- a/src/ade_cli/crop.py
+++ b/src/ade_cli/crop.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import typer
 
-from . import elements, items, store
+from . import attach, elements, items, store
 from .config import ade_home
 from .history import require_job_id, resolve_or_exit
 from .output import EXIT_FAILED, EXIT_USAGE, JSON_FLAG, emit, exit_with, tilde
@@ -52,8 +52,14 @@ def crop_element_to_file(
     failure. ``source_item_id`` names the parse item whose recorded source
     renders the imagery when it isn't ``item_id`` itself (a referencing
     extract item); the PNG still lands under ``item_id``'s ``crops/``."""
-    meta = jobs.read_json(source_item_id or item_id, "meta.json") or {}
-    image = crop_box(meta.get("source"), record["page"], record["box"], dpi=dpi)
+    owner = source_item_id or item_id
+    meta = jobs.read_json(owner, "meta.json") or {}
+    # URL parses render from their attached copy when one exists (#169);
+    # local parses keep the recorded source and its honest errors.
+    image = crop_box(
+        attach.renderable_source(jobs, owner, meta),
+        record["page"], record["box"], dpi=dpi,
+    )
     if output is None:
         output = jobs.item_dir(item_id) / "crops" / f"{record['id']}@{dpi}dpi.png"
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -230,7 +236,12 @@ def crop(
     )
     # One drift check per invocation, not per element: the batch renders
     # from a single recorded source, and hashing it once is the whole cost.
-    drift = source_drift_note(jobs.read_json(parse_item_id, "meta.json"))
+    # URL items have no drift check (no recorded content hash); a render
+    # from their attached copy carries the unverified-bytes caveat instead.
+    parse_meta = jobs.read_json(parse_item_id, "meta.json")
+    drift = source_drift_note(parse_meta) or attach.caveat(
+        jobs, parse_item_id, parse_meta
+    )
     directory, single_file = _crop_target(
         jobs, item_id, output, dpi=dpi, batch=batch, as_json=as_json
     )
@@ -254,13 +265,25 @@ def crop(
             # Source-level failures (missing file, missing page) are the
             # whole batch's failure, not one element's: stopping is the
             # never-a-stale-image rule, and a partial batch that quietly
-            # skipped pages would read as a complete one.
+            # skipped pages would read as a complete one. URL items get
+            # the id-bearing fetch action instead of "restore the source"
+            # (#169 — there was never a local file to restore).
+            message = error.message
+            if "parsed from a URL" in message:
+                message += (
+                    f" Fetch it with `ade view {parse_item_id} --download`, "
+                    "then re-run this crop."
+                )
+                tail = ""
+            else:
+                tail = (
+                    " (a crop is never served from stale imagery; restore "
+                    "the source and re-run)"
+                )
             exit_with(
                 {"error": error.kind, "job_item_id": item_id,
-                 "element_id": record["id"], "message": error.message},
-                f"Cannot crop {record['id']}: {error.message} (a crop is "
-                "never served from stale imagery; restore the source and "
-                "re-run).",
+                 "element_id": record["id"], "message": message},
+                f"Cannot crop {record['id']}: {message}{tail}.",
                 as_json=as_json,
                 code=EXIT_FAILED,
             )

--- a/src/ade_cli/extract.py
+++ b/src/ade_cli/extract.py
@@ -96,7 +96,9 @@ def _load_schema(spec: str, *, as_json: bool) -> dict:
                     "error": "bad_schema",
                     "message": f"--schema file {spec} is unreadable: {error}",
                 },
-                f"--schema {spec!r} names a file that cannot be read "
+                # '{spec}' rather than {spec!r}: repr doubles every
+                # backslash of a Windows path (#172).
+                f"--schema '{spec}' names a file that cannot be read "
                 f"({error}); fix the file or pass an inline JSON object.",
                 as_json=as_json,
                 code=EXIT_USAGE,
@@ -113,7 +115,7 @@ def _load_schema(spec: str, *, as_json: bool) -> dict:
                 "error": "bad_schema",
                 "message": "--schema must be a JSON Schema file or an inline JSON object.",
             },
-            f"--schema {spec!r} is neither a readable file nor an inline "
+            f"--schema '{spec}' is neither a readable file nor an inline "
             "JSON object; pass a JSON Schema file path or a JSON object literal.",
             as_json=as_json,
             code=EXIT_USAGE,
@@ -597,11 +599,12 @@ def extract(
             else ""
         )
         next_cmds = ["ade history list --json"]
-        if parse_item_id is not None:
-            # The referenced parse item's viewer renders this extraction as
-            # a layer; a bring-your-own-markdown item has no parse and never
-            # will, so hinting at the viewer would hint at an error.
-            next_cmds.append(f"ade view {items.short_id(jobs, parse_item_id)} --open")
+        # The extract item owns its viewer (decision 8 as amended
+        # 2026-07-21): it renders THIS extraction — over the referenced
+        # parse's pages, or the copied-in markdown alone. The parse item's
+        # viewer deliberately holds parse only, so hinting it here sent
+        # every user to an empty extractions pane (#170).
+        next_cmds.append(f"ade view {items.short_id(jobs, item_id)} --open")
         next_line = "\n  next:     " + "   ·   ".join(next_cmds)
         payload = {
             "status": "extracted",

--- a/src/ade_cli/filelock.py
+++ b/src/ade_cli/filelock.py
@@ -66,6 +66,20 @@ if os.name == "nt":
         except OSError:
             return False
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        # Explicit signatures (same reason as historyjs._alive): a
+        # pointer-sized HANDLE must not pass through ctypes' c_int
+        # defaults on 64-bit Windows.
+        kernel32.GetFileType.restype = wintypes.DWORD
+        kernel32.GetFileType.argtypes = [wintypes.HANDLE]
+        kernel32.PeekNamedPipe.restype = wintypes.BOOL
+        kernel32.PeekNamedPipe.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
         file_type = kernel32.GetFileType(wintypes.HANDLE(handle))
         if file_type == FILE_TYPE_DISK:
             return True  # redirected from a file: reads never block

--- a/src/ade_cli/filelock.py
+++ b/src/ade_cli/filelock.py
@@ -1,17 +1,90 @@
-"""Cross-platform advisory file lock — the one module allowed to import
-platform-specific locking primitives (fcntl on POSIX, msvcrt on Windows),
-so the frozen binary starts everywhere. Same advisory posture as before:
-every mutator is this CLI."""
+"""Cross-platform advisory file lock and stream probing — the one module
+allowed to import platform-specific primitives (fcntl on POSIX, msvcrt on
+Windows), so the frozen binary starts everywhere. Same advisory posture
+as before: every mutator is this CLI.
+
+Besides the lock, this hosts ``stdin_ready`` (#168): "is reading stdin
+guaranteed not to block?", answered by select() on POSIX and
+PeekNamedPipe on Windows — select() there supports only sockets, so
+probing piped stdin raised WinError 10093 every time and the documented
+``echo $KEY | ade auth login`` pattern was silently never detected."""
 
 from __future__ import annotations
 
 import os
+import select
+import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
+
+# Poll cadence of the Windows pipe probe — PeekNamedPipe has no built-in
+# wait, so readiness is sampled inside the same timeout budget select()
+# spends on POSIX.
+_PIPE_POLL_SECONDS = 0.01
+
+
+def poll_until_ready(
+    probe: Callable[[], int | None],
+    *,
+    timeout: float,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> bool:
+    """Sample ``probe`` until a stream is safely readable or ``timeout``
+    passes. ``probe`` reports bytes waiting, or None when the stream has
+    ended (a broken pipe / EOF — reading returns immediately, so that
+    counts as ready). The pure half of the Windows probe, kept separate
+    so its decision table is testable on every platform."""
+    deadline = monotonic() + timeout
+    while True:
+        available = probe()
+        if available is None or available > 0:
+            return True
+        if monotonic() >= deadline:
+            return False
+        sleep(_PIPE_POLL_SECONDS)
 
 if os.name == "nt":
     import msvcrt
+
+    def stdin_ready(fileno: int, *, timeout: float) -> bool:  # pragma: no cover
+        """Whether reading ``fileno`` cannot block, via PeekNamedPipe.
+
+        Files are always readable; anonymous pipes are peeked without
+        consuming; console handles never reach here (tty callers bail
+        first). Windows-only body — covered by the Windows QA suite; the
+        decision table lives in poll_until_ready above.
+        """
+        import ctypes
+        from ctypes import wintypes
+
+        FILE_TYPE_DISK = 0x0001
+        FILE_TYPE_PIPE = 0x0003
+        try:
+            handle = msvcrt.get_osfhandle(fileno)
+        except OSError:
+            return False
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        file_type = kernel32.GetFileType(wintypes.HANDLE(handle))
+        if file_type == FILE_TYPE_DISK:
+            return True  # redirected from a file: reads never block
+        if file_type != FILE_TYPE_PIPE:
+            return False  # char device/unknown: nothing was piped
+
+        def probe() -> int | None:
+            available = wintypes.DWORD()
+            ok = kernel32.PeekNamedPipe(
+                wintypes.HANDLE(handle),
+                None, 0, None,
+                ctypes.byref(available),
+                None,
+            )
+            if not ok:
+                return None  # broken pipe: the writer is gone, read = EOF
+            return available.value
+
+        return poll_until_ready(probe, timeout=timeout)
 
     @contextmanager
     def exclusive(path: Path) -> Iterator[None]:
@@ -39,6 +112,14 @@ if os.name == "nt":
 
 else:
     import fcntl
+
+    def stdin_ready(fileno: int, *, timeout: float) -> bool:
+        """Whether reading ``fileno`` cannot block — select(), the POSIX
+        answer."""
+        try:
+            return bool(select.select([fileno], [], [], timeout)[0])
+        except OSError:
+            return False
 
     @contextmanager
     def exclusive(path: Path) -> Iterator[None]:

--- a/src/ade_cli/guarantee.py
+++ b/src/ade_cli/guarantee.py
@@ -245,6 +245,15 @@ class Guarantee:
         mode = "off" if self.as_json else ("tty" if self.stderr_tty else "plain")
         self.progress = Progress(self.clock, mode)
 
+    def _item_label(self) -> str:
+        """The job item id as a human-line suffix (#167): every message
+        that names a run must also name the local key the next command
+        (view, extract, history clear, a resumed run) actually takes —
+        the --json payloads always carried it via ``context``, but the
+        human lines used to surface only the run id."""
+        item_id = self.context.get("job_item_id")
+        return f" (job item {item_id})" if item_id else ""
+
     def ensure(self) -> Outcome:
         """Run claim → submit → poll to a completed job with an inline
         result; every other outcome exits with its machine payload."""
@@ -254,8 +263,9 @@ class Guarantee:
             self.progress.close()
             if job_id:
                 human = (
-                    f"Run {job_id} continues server-side; re-run the "
-                    "same command to resume waiting (it will never resubmit)."
+                    f"Run {job_id}{self._item_label()} continues "
+                    "server-side; re-run the same command to resume "
+                    "waiting (it will never resubmit)."
                 )
             else:
                 human = self.interrupted_no_job_hint
@@ -361,7 +371,8 @@ class Guarantee:
                     reason = error.get("message") or error.get("code") or status
                     exit_with(
                         {"status": status, "run_id": job_id, **self.context, "reason": reason},
-                        f"{self.noun} {status}: {reason} (run {job_id}).",
+                        f"{self.noun} {status}: {reason} "
+                        f"(run {job_id}{self._item_label()}).",
                         as_json=self.as_json,
                         code=EXIT_FAILED,
                     )
@@ -374,7 +385,8 @@ class Guarantee:
                 self.progress.close()
                 exit_with(  # a status this CLI doesn't know is never silent success
                     {"error": "unexpected_status", "status": status, "run_id": job_id, **self.context},
-                    f"Unexpected run status {status!r} (run {job_id}); upgrade ade "
+                    f"Unexpected run status {status!r} "
+                    f"(run {job_id}{self._item_label()}); upgrade ade "
                     "(re-run the installer, or `uv tool upgrade ade-cli`) and retry.",
                     as_json=self.as_json,
                     code=EXIT_FAILED,
@@ -395,16 +407,17 @@ class Guarantee:
             output_url = payload.get("output_url")
             if output_url:
                 human = (
-                    f"Run {job_id} completed without an inline result; the "
-                    f"response carries output_url={output_url}, which "
-                    "ade does not fetch."
+                    f"Run {job_id}{self._item_label()} completed without "
+                    f"an inline result; the response carries "
+                    f"output_url={output_url}, which ade does not fetch."
                 )
             elif "data" in payload:
                 # The pre-cutover envelope: updating ade would not help —
                 # an up-to-date CLI is exactly what fails here. The endpoint
                 # simply hasn't promoted to the API release this CLI speaks.
                 human = (
-                    f"Run {job_id} completed, but {self.endpoint_label} "
+                    f"Run {job_id}{self._item_label()} completed, but "
+                    f"{self.endpoint_label} "
                     "answered with the pre-cutover response contract "
                     "(top-level 'data' instead of 'result'). This CLI is "
                     "current; that API target has not promoted to the new "
@@ -414,8 +427,9 @@ class Guarantee:
                 )
             else:
                 human = (
-                    f"Run {job_id} completed without an inline result; the "
-                    f"response's top-level keys were: {', '.join(sorted(payload))}."
+                    f"Run {job_id}{self._item_label()} completed without "
+                    f"an inline result; the response's top-level keys "
+                    f"were: {', '.join(sorted(payload))}."
                 )
             # The diagnosis rides on the ticket: job.json is the durable
             # record history list reads the reason from.
@@ -470,7 +484,8 @@ class Guarantee:
                 **self.context,
                 "reason": problem,
             },
-            f"Run {outcome.job_id} completed, but its result does not match "
+            f"Run {outcome.job_id}{self._item_label()} completed, but "
+            "its result does not match "
             f"the contract this CLI understands: {problem}. The API "
             "usually runs ahead of the CLI — upgrade ade (re-run the "
             "installer, or `uv tool upgrade ade-cli`), then re-run the "
@@ -613,8 +628,9 @@ class Guarantee:
                         self.progress.close()
                         exit_with(
                             {"status": "pending", "run_id": None, **self.context},
-                            "Another process took over this guarantee; "
-                            "re-run the same command to join it.",
+                            f"Another process took over this guarantee"
+                            f"{self._item_label()}; re-run the same "
+                            "command to join it.",
                             as_json=self.as_json,
                             code=EXIT_PENDING,
                         )

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -274,6 +274,9 @@ RESULTS: dict[str, dict] = {
              "--force re-run after this extraction"),
             ("created_at / completed_at", "epoch seconds (null when unknown)"),
         ],
+        "note": "Ordered newest submission first (timestamp-less items "
+        "last), matching the viewer sidebar; --asc restores oldest-first. "
+        "The --json array follows the same order.",
     },
     "history clear": {
         "shape": "object",

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -277,8 +277,9 @@ RESULTS: dict[str, dict] = {
         "note": "Ordered newest submission first (timestamp-less items "
         "last), matching the viewer sidebar; --asc restores oldest-first. "
         "Capped at the newest 100 items by default — --limit N adjusts, "
-        "--all lifts the cap, and a capped run says so on stderr. The "
-        "--json array follows the same order and cap.",
+        "--all lifts the cap, and a capped run says so up front (the "
+        "first line of the listing; on stderr for --json). The --json "
+        "array follows the same order and cap.",
     },
     "history clear": {
         "shape": "object",

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -182,6 +182,10 @@ RESULTS: dict[str, dict] = {
             ("artifacts", "artifact filenames written there"),
             ("markdown", "the parse markdown — only with --include markdown"),
             ("elements", "the flat projection — only with --include elements"),
+            ("kept_copy", "with --keep-copy: whether the URL document's "
+             "copy was stored in the job item"),
+            ("keep_copy_error", "with --keep-copy: why the copy could not "
+             "be stored (the parse itself still succeeded)"),
         ],
     },
     "extract": {
@@ -248,6 +252,8 @@ RESULTS: dict[str, dict] = {
             ("built", "true when this run rebuilt the artifact"),
             ("pages_embedded", "pages inlined; the rest load from sidecars"),
             ("note", "why the render weakened, when it did (else null)"),
+            ("downloaded", "with --download: true when this run fetched "
+             "the URL document into the job item (false: already attached)"),
             ("deep_link", "view.html#element=... when --element-id was given"),
             ("history_items", "items in the rebuilt sidebar read model"),
             ("sidebar_sync", "true when sibling viewers build in the background"),
@@ -470,6 +476,12 @@ STORE_LAYOUT = [
         "path": "  markdown.md",
         "what": "bring-your-own-markdown extract items: the input markdown, "
         "copied in (spans index exactly these bytes)",
+    },
+    {
+        "path": "  document.<ext>",
+        "what": "URL parses: the attached document copy (`parse "
+        "--keep-copy` / `view --download`) page previews and crops render "
+        "from — unverified against the parsed run",
     },
     {
         "path": "  view.html / crops/",

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -409,7 +409,10 @@ CONVENTIONS = [
         "job item ids",
         "Store commands take a job item id or an unambiguous prefix. "
         "Discover ids with `history list`; ambiguous or unknown ids error "
-        "with candidates listed.",
+        "with candidates listed. Distinct from the server-side run id: "
+        "--json payloads report that as run_id, and on-disk records spell "
+        "the same value job_id (the wire's name) — neither is ever a "
+        "job item id.",
     ),
     (
         "guarantees",
@@ -450,7 +453,8 @@ STORE_LAYOUT = [
     {
         "path": "  meta.json",
         "what": "commit record: kind, source, identity, params, state, "
-        "timestamps, artifact index",
+        "timestamps, artifact index. Its job_id field is the server-side "
+        "run id (= run_id in --json payloads), never the job item id",
     },
     {
         "path": "  job.json",
@@ -663,6 +667,7 @@ def _human(reference: dict, *, scoped: bool) -> str:
     lines.append("store layout")
     for entry in reference["store"]["layout"]:
         lines.append(f"  {entry['path']:<42}  {entry['what']}")
+    lines.append(f"  note: {reference['store']['note']}")
     lines.append("")
     lines.append("topics — conceptual pages, e.g. `ade help workflow`")
     for topic in reference["topics"]:
@@ -739,6 +744,12 @@ def help_command(
         "exit_states": EXIT_STATES,
         "store": {
             "home": "~/.ade (ADE_HOME overrides)",
+            # One vocabulary note for every on-disk record: job_id there
+            # is the wire's spelling of the run id.
+            "note": "On-disk records (meta.json, job.json, parse/ref.json) "
+            "spell the server-side run id as job_id — the wire contract's "
+            "name for the same value --json payloads report as run_id. "
+            "Neither is the job item id (the jobs/<id>/ folder name).",
             "layout": STORE_LAYOUT,
         },
     }

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -276,7 +276,9 @@ RESULTS: dict[str, dict] = {
         ],
         "note": "Ordered newest submission first (timestamp-less items "
         "last), matching the viewer sidebar; --asc restores oldest-first. "
-        "The --json array follows the same order.",
+        "Capped at the newest 100 items by default — --limit N adjusts, "
+        "--all lifts the cap, and a capped run says so on stderr. The "
+        "--json array follows the same order and cap.",
     },
     "history clear": {
         "shape": "object",

--- a/src/ade_cli/history.py
+++ b/src/ade_cli/history.py
@@ -36,15 +36,35 @@ ASC_FLAG = typer.Option(
     "the viewer sidebar.",
 )
 
+# The listing cap: a long-lived store holds thousands of items, and an
+# uncapped default would drown the recent runs the listing exists to
+# answer for. The cap always keeps the NEWEST items — with --asc they
+# just present oldest-first (a chronological tail, like `tail -100`).
+DEFAULT_LIST_LIMIT = 100
+LIMIT_FLAG = typer.Option(
+    DEFAULT_LIST_LIMIT,
+    "--limit",
+    min=1,
+    help=f"Keep only the newest N items (default {DEFAULT_LIST_LIMIT}), "
+    "whatever the order; --all lifts the cap.",
+)
+LIST_ALL_FLAG = typer.Option(
+    False, "--all", help="List every stored job item — no limit."
+)
+
 
 @history_app.callback(invoke_without_command=True)
 def _history_default(
-    ctx: typer.Context, asc: bool = ASC_FLAG, as_json: bool = JSON_FLAG
+    ctx: typer.Context,
+    asc: bool = ASC_FLAG,
+    limit: int = LIMIT_FLAG,
+    list_all: bool = LIST_ALL_FLAG,
+    as_json: bool = JSON_FLAG,
 ) -> None:
     """Inspect and manage the local job-item store; bare `ade history`
     defaults to `ade history list`."""
     if ctx.invoked_subcommand is None:
-        list_items(ctx, asc=asc, as_json=as_json)
+        list_items(ctx, asc=asc, limit=limit, list_all=list_all, as_json=as_json)
 
 
 def require_job_id(token: str | None, *, as_json: bool) -> str:
@@ -81,13 +101,17 @@ def resolve_or_exit(jobs: store.JobStore, token: str, *, as_json: bool) -> str:
 def _grouped(records: list[dict]) -> list[tuple[dict, bool]]:
     """History order with linkage: every parse item (and every extract item
     without a living parent) is a top row; extract items referencing a
-    still-present parse render indented beneath it."""
+    still-present parse render indented beneath it. A child whose parent
+    fell outside the listing window (--limit) renders as its own top row —
+    the cap must never silently drop a record the --json array carries."""
+    ids = {record["job_item_id"] for record in records}
     children: dict[str, list[dict]] = {}
     tops: list[dict] = []
     for record in records:
         ref = record.get("parse") or {}
-        if ref.get("job_item_id") and not ref.get("missing"):
-            children.setdefault(ref["job_item_id"], []).append(record)
+        parent_id = ref.get("job_item_id")
+        if parent_id and not ref.get("missing") and parent_id in ids:
+            children.setdefault(parent_id, []).append(record)
         else:
             tops.append(record)
     rows: list[tuple[dict, bool]] = []
@@ -109,29 +133,61 @@ _STATE_STYLES = {
 
 @history_app.command("list")
 def list_items(
-    ctx: typer.Context, asc: bool = ASC_FLAG, as_json: bool = JSON_FLAG
+    ctx: typer.Context,
+    asc: bool = ASC_FLAG,
+    limit: int = LIMIT_FLAG,
+    list_all: bool = LIST_ALL_FLAG,
+    as_json: bool = JSON_FLAG,
 ) -> None:
     """List stored job items: id, kind, state, env, params, source —
-    newest submission first (--asc for oldest first). Extract items
-    referencing a parse item indent beneath it. Bare `ade history`
-    defaults to this command."""
+    the newest 100 submissions first (--limit/--all adjust, --asc for
+    oldest first). Extract items referencing a parse item indent
+    beneath it. Bare `ade history` defaults to this command."""
     jobs = store.JobStore(ade_home())
     ports: Ports = ctx.obj
     records = items.item_records(jobs)
+    # The sidebar read model always heals from the FULL scan — the
+    # listing cap is presentation only.
     historyjs.write(jobs, records, now=ports.clock.now())
     # Newest first by default — the run the user just did leads, matching
-    # the sidebar; --asc keeps the chronological read. Applied to both
-    # renderings AND the --json array, so the machine order never
-    # disagrees with what the terminal showed.
-    ordered = records if asc else items.newest_first(records)
-    rows = _grouped(ordered)
+    # the sidebar; --asc keeps the chronological read. The cap keeps the
+    # newest N whatever the order (a chronological tail under --asc).
+    # Both apply to the renderings AND the --json array, so the machine
+    # order never disagrees with what the terminal showed.
+    newest = items.newest_first(records)
+    kept = newest if list_all else newest[: limit]
+    if asc:
+        kept = sorted(
+            kept,
+            key=lambda r: (
+                r["submitted_at"] is None,
+                r["submitted_at"] or 0.0,
+                r["job_item_id"],
+            ),
+        )
+    hidden = len(records) - len(kept)
+    footer = (
+        f"showing the newest {len(kept)} of {len(records)} job items — "
+        "pass --all (or --limit N) for the rest"
+        if hidden > 0
+        else ""
+    )
+    rows = _grouped(kept)
     if not as_json and ports.stdout_is_tty() and records:
         # A real table is a TTY-only upgrade; piped output below stays
         # line-oriented (one row per item, children indented).
         _render_table(jobs, rows)
+        if footer:
+            typer.echo(footer)
         return
+    if as_json and footer:
+        # The --json array is silently shorter than the store; say so on
+        # stderr, where it can never pollute the machine payload.
+        typer.echo(footer, err=True)
     human = "\n".join(_plain_line(record, indent) for record, indent in rows)
-    emit(ordered, human or "No job items stored.", as_json=as_json)
+    if footer:
+        human += f"\n{footer}"
+    emit(kept, human or "No job items stored.", as_json=as_json)
 
 
 def _plain_line(record: dict, indent: bool) -> str:

--- a/src/ade_cli/history.py
+++ b/src/ade_cli/history.py
@@ -26,12 +26,25 @@ from .ports import Ports
 history_app = typer.Typer(name="history", help="Inspect and manage the local job-item store.")
 
 
+# The listing's oldest-first escape hatch, shared by `history list` and
+# the bare-`history` default so both spell it identically.
+ASC_FLAG = typer.Option(
+    False,
+    "--asc",
+    help="Oldest submission first (the pre-1.0.3 order). The listing "
+    "defaults to newest first — the run you just did leads, matching "
+    "the viewer sidebar.",
+)
+
+
 @history_app.callback(invoke_without_command=True)
-def _history_default(ctx: typer.Context, as_json: bool = JSON_FLAG) -> None:
+def _history_default(
+    ctx: typer.Context, asc: bool = ASC_FLAG, as_json: bool = JSON_FLAG
+) -> None:
     """Inspect and manage the local job-item store; bare `ade history`
     defaults to `ade history list`."""
     if ctx.invoked_subcommand is None:
-        list_items(ctx, as_json=as_json)
+        list_items(ctx, asc=asc, as_json=as_json)
 
 
 def require_job_id(token: str | None, *, as_json: bool) -> str:
@@ -95,22 +108,30 @@ _STATE_STYLES = {
 
 
 @history_app.command("list")
-def list_items(ctx: typer.Context, as_json: bool = JSON_FLAG) -> None:
-    """List stored job items: id, kind, state, env, params, source. Extract
-    items referencing a parse item indent beneath it. Bare `ade history`
+def list_items(
+    ctx: typer.Context, asc: bool = ASC_FLAG, as_json: bool = JSON_FLAG
+) -> None:
+    """List stored job items: id, kind, state, env, params, source —
+    newest submission first (--asc for oldest first). Extract items
+    referencing a parse item indent beneath it. Bare `ade history`
     defaults to this command."""
     jobs = store.JobStore(ade_home())
     ports: Ports = ctx.obj
     records = items.item_records(jobs)
     historyjs.write(jobs, records, now=ports.clock.now())
-    rows = _grouped(records)
+    # Newest first by default — the run the user just did leads, matching
+    # the sidebar; --asc keeps the chronological read. Applied to both
+    # renderings AND the --json array, so the machine order never
+    # disagrees with what the terminal showed.
+    ordered = records if asc else items.newest_first(records)
+    rows = _grouped(ordered)
     if not as_json and ports.stdout_is_tty() and records:
         # A real table is a TTY-only upgrade; piped output below stays
         # line-oriented (one row per item, children indented).
         _render_table(jobs, rows)
         return
     human = "\n".join(_plain_line(record, indent) for record, indent in rows)
-    emit(records, human or "No job items stored.", as_json=as_json)
+    emit(ordered, human or "No job items stored.", as_json=as_json)
 
 
 def _plain_line(record: dict, indent: bool) -> str:
@@ -122,7 +143,8 @@ def _plain_line(record: dict, indent: bool) -> str:
         # environment field read as "?", never a guessed default.
         + f"{record['state']:<10}  {record.get('environment') or '?':<10}  "
         # When the run was submitted — the ordering key, so the listing's
-        # oldest-first order is legible. Local time, like the table.
+        # order (newest first; --asc for oldest) is legible. Local time,
+        # like the table.
         + f"{_submitted_cell(record):<16}  "
         + f"{items.compact_params(record)}  "
         + (record["source"] or "?")

--- a/src/ade_cli/history.py
+++ b/src/ade_cli/history.py
@@ -166,9 +166,12 @@ def list_items(
             ),
         )
     hidden = len(records) - len(kept)
-    footer = (
+    # The cap notice LEADS the listing — a reader must know the view is
+    # capped before scanning it, not after — and names both ways out.
+    notice = (
         f"showing the newest {len(kept)} of {len(records)} job items — "
-        "pass --all (or --limit N) for the rest"
+        "run `ade history list --all` for the full list (or --limit N "
+        "for a different cap)"
         if hidden > 0
         else ""
     )
@@ -176,17 +179,17 @@ def list_items(
     if not as_json and ports.stdout_is_tty() and records:
         # A real table is a TTY-only upgrade; piped output below stays
         # line-oriented (one row per item, children indented).
+        if notice:
+            typer.echo(notice)
         _render_table(jobs, rows)
-        if footer:
-            typer.echo(footer)
         return
-    if as_json and footer:
+    if as_json and notice:
         # The --json array is silently shorter than the store; say so on
         # stderr, where it can never pollute the machine payload.
-        typer.echo(footer, err=True)
+        typer.echo(notice, err=True)
     human = "\n".join(_plain_line(record, indent) for record, indent in rows)
-    if footer:
-        human += f"\n{footer}"
+    if notice:
+        human = f"{notice}\n{human}"
     emit(kept, human or "No job items stored.", as_json=as_json)
 
 

--- a/src/ade_cli/historyjs.py
+++ b/src/ade_cli/historyjs.py
@@ -27,14 +27,53 @@ ARTIFACT = "history.js"
 BUILDING_MARKER = ".viewer.building"
 
 
-def _alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except PermissionError:
-        return True  # exists, owned by someone else — still a live claim
-    except (ProcessLookupError, ValueError, OverflowError):
-        return False
-    return True
+if os.name == "nt":  # pragma: no cover - exercised on Windows only
+
+    def _alive(pid: int) -> bool:
+        """Whether ``pid`` is a live process, probed via the Win32 API.
+
+        The POSIX idiom below (``os.kill(pid, 0)``) is doubly unusable
+        here (#171): on Windows ``os.kill`` calls TerminateProcess for
+        any signal other than the CTRL events — signal 0 included — so
+        probing a LIVE builder would kill it mid-build; and probing a
+        dead pid raises a bare OSError (WinError 87) rather than
+        ProcessLookupError, which crashed every view/history run that
+        saw a stale ``.viewer.building`` marker."""
+        import ctypes
+        from ctypes import wintypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        ERROR_ACCESS_DENIED = 5
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+        )
+        if not handle:
+            # Access denied means the pid exists (someone else's process)
+            # — a live claim; anything else (invalid parameter for a pid
+            # no process holds) means dead.
+            return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return True  # exists but unreadable — still a live claim
+            return code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+
+else:
+
+    def _alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except PermissionError:
+            return True  # exists, owned by someone else — still a live claim
+        # Bare OSError included (#171): "no such process" must never crash
+        # the scan on a platform that spells it differently than ESRCH.
+        except (ProcessLookupError, ValueError, OverflowError, OSError):
+            return False
+        return True
 
 
 def viewer_status(store: JobStore, item_id: str) -> str:

--- a/src/ade_cli/historyjs.py
+++ b/src/ade_cli/historyjs.py
@@ -152,18 +152,11 @@ def write(store: JobStore, records: list[dict], *, now: float) -> Path:
     """Rewrite ``<store home>/history.js`` from already-scanned records.
 
     Items are emitted latest submission first — the sidebar renders the
-    file in order, and the newest run is the one the user just did.
-    ``history list`` keeps its own oldest-first order; timestamp-less
-    husks sort last either way.
+    file in order, and the newest run is the one the user just did
+    (``history list`` defaults to the same order; its ``--asc`` flag is
+    presentation-only and never reaches this file).
     """
-    ordered = sorted(
-        records,
-        key=lambda r: (
-            r["submitted_at"] is None,
-            -(r["submitted_at"] or 0.0),
-            r["job_item_id"],
-        ),
-    )
+    ordered = items.newest_first(records)
     payload = {
         "generated_at": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
         "items": [_sidebar_item(store, record) for record in ordered],

--- a/src/ade_cli/historyjs.py
+++ b/src/ade_cli/historyjs.py
@@ -46,6 +46,19 @@ if os.name == "nt":  # pragma: no cover - exercised on Windows only
         STILL_ACTIVE = 259
         ERROR_ACCESS_DENIED = 5
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        # Explicit signatures: ctypes defaults restype to c_int, which
+        # truncates a pointer-sized HANDLE on 64-bit Windows — the probe
+        # would then misreport liveness and leak the real handle.
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = [
+            wintypes.DWORD, wintypes.BOOL, wintypes.DWORD,
+        ]
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.GetExitCodeProcess.argtypes = [
+            wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD),
+        ]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
         handle = kernel32.OpenProcess(
             PROCESS_QUERY_LIMITED_INFORMATION, False, pid
         )

--- a/src/ade_cli/items.py
+++ b/src/ade_cli/items.py
@@ -206,9 +206,10 @@ def item_record(store: JobStore, item_id: str) -> dict:
 
 
 def item_records(store: JobStore) -> list[dict]:
-    """All items' records in history order: oldest submission first (ties
-    and timestamp-less husks by id) — the flat answer to "what runs did I
-    do here". Re-scanned every call; zero HTTP."""
+    """All items' records, oldest submission first (ties and
+    timestamp-less husks by id) — the internal scan order; presentation
+    surfaces re-order via ``newest_first`` (the ``history list`` default
+    and the sidebar's order). Re-scanned every call; zero HTTP."""
     records = [item_record(store, item_id) for item_id in item_ids(store)]
     records.sort(
         key=lambda r: (
@@ -218,6 +219,20 @@ def item_records(store: JobStore) -> list[dict]:
         )
     )
     return records
+
+
+def newest_first(records: list[dict]) -> list[dict]:
+    """Records re-ordered latest submission first — what listings and the
+    sidebar show by default (the newest run is the one the user just
+    did); timestamp-less husks sort last either way."""
+    return sorted(
+        records,
+        key=lambda r: (
+            r["submitted_at"] is None,
+            -(r["submitted_at"] or 0.0),
+            r["job_item_id"],
+        ),
+    )
 
 
 def live_parse(store: JobStore, item_id: str) -> tuple[dict, dict] | None:

--- a/src/ade_cli/main.py
+++ b/src/ade_cli/main.py
@@ -73,7 +73,10 @@ class AdeGroup(LedgerGroup):
                 break
             flags.append(token)
         if "--id-only" in flags:
-            typer.echo(error.format_message(), err=True)
+            # The payload's message, not format_message() directly: the
+            # payload builder also undoes typer's repr()-doubled
+            # backslashes on Windows paths (#172).
+            typer.echo(click_usage_payload(error)["message"], err=True)
             raise SystemExit(EXIT_USAGE)
         if "--json" in flags:
             typer.echo(json.dumps(click_usage_payload(error), indent=2))

--- a/src/ade_cli/output.py
+++ b/src/ade_cli/output.py
@@ -145,6 +145,14 @@ def click_usage_payload(error: UsageError) -> dict:
         payload["error"] = "bad_parameter"
         if spelled:
             payload["param"] = spelled
+    # typer's vendored path validation formats the offending path with
+    # repr(), doubling every backslash on Windows (#172) — undo it for
+    # path-typed params so the message carries the path as typed. (UNC
+    # prefixes come back right too: repr's \\\\server\\share collapses to
+    # \\server\share.)
+    kind = getattr(getattr(param, "type", None), "name", "")
+    if kind in ("path", "file", "filename", "directory"):
+        payload["message"] = payload["message"].replace("\\\\", "\\")
     return payload
 
 

--- a/src/ade_cli/parse.py
+++ b/src/ade_cli/parse.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import typer
 
-from . import credentials, elements, items, oauth, store
+from . import attach, credentials, elements, items, oauth, store
 from .config import DEFAULT_ENVIRONMENT, ENVIRONMENTS, ade_home, resolve_target
 from .gateway import Gateway
 from . import guarantee as lifecycle
@@ -152,6 +152,15 @@ def parse(
         help="Re-parse even if already parsed, or abandon an unreadable job "
         "for a fresh one (bills a new parse).",
     ),
+    keep_copy: bool = typer.Option(
+        False, "--keep-copy",
+        help="--document-url only: also download the document into the "
+        "job item (plain HTTP, no API credits) so page previews and "
+        "crops render locally — fetched now, while the URL (often "
+        "pre-signed) still works. Without it, URL parses have no local "
+        "bytes and the viewer explains how to fetch them later "
+        "(`ade view <id> --download`).",
+    ),
     include: list[Include] = typer.Option(
         [],
         "--include",
@@ -175,6 +184,17 @@ def parse(
         exit_with(
             {"error": "bad_source", "message": "Provide exactly one of -d/--document or --document-url."},
             "Provide exactly one of -d/--document or --document-url.",
+            as_json=as_json,
+            code=EXIT_USAGE,
+        )
+    if keep_copy and document_url is None:
+        message = (
+            "--keep-copy applies to --document-url parses; a local parse "
+            "already renders previews from its file."
+        )
+        exit_with(
+            {"error": "keep_copy_local_source", "message": message},
+            message,
             as_json=as_json,
             code=EXIT_USAGE,
         )
@@ -258,6 +278,7 @@ def parse(
         cached: bool,
         stored: bool = True,
         completed_at: float | None = None,
+        copy_info: dict | None = None,
     ) -> None:
         meta = data["metadata"]
         billing = meta["billing"]
@@ -296,6 +317,21 @@ def parse(
             f"\n  next:    ade view {ref} --open"
             f"   ·   ade extract {ref} --schema <schema.json>"
         )
+        copy_line = ""
+        if copy_info is not None:
+            if copy_info.get("error"):
+                # The parse itself succeeded and billed; a failed copy is
+                # a warning with the later remediation, never a failure.
+                copy_line = (
+                    f"\n  copy:    keep-copy failed — {copy_info['error']} "
+                    f"(the parse succeeded; `ade view {ref} --download` "
+                    "can fetch the copy later)"
+                )
+            else:
+                copy_line = (
+                    f"\n  copy:    {copy_info['name']} saved into the job "
+                    "item — page previews and crops render locally"
+                )
         payload = {
             "status": "parsed",
             # The server-side run id — user-facing name for what the wire
@@ -314,6 +350,10 @@ def parse(
             "store_dir": str(store_dir),
             "artifacts": PARSE_ARTIFACTS,
         }
+        if copy_info is not None:
+            payload["kept_copy"] = not copy_info.get("error")
+            if copy_info.get("error"):
+                payload["keep_copy_error"] = copy_info["error"]
         # Asked-for bulk artifacts ride on stdout, so a caller never has to
         # reconstruct a store path to reach the result it just paid for.
         # Computed from the response in hand — the same bytes the artifacts
@@ -340,10 +380,35 @@ def parse(
                 f"\n  pages:   {meta['page_count']} ({failed_note})"
                 f"\n  credits: {billing['total_credits']} ({billing['service_tier']})"
                 + saved_line
+                + copy_line
                 + next_line
             ),
             as_json=as_json,
         )
+
+    def maybe_keep_copy() -> dict | None:
+        """The --keep-copy download (#169), after the parse settled: while
+        the URL — often pre-signed — still works. Idempotent (an attached
+        copy is kept), and never fails the parse: the billable work
+        already succeeded."""
+        if not keep_copy:
+            return None
+        meta = jobs.read_json(item_id, "meta.json") or {}
+        if attach.attached_file(jobs, item_id, meta) is not None:
+            return {"kept": True, "name": meta.get("attached_source")}
+        if not meta.get("source"):
+            return {
+                "kept": False,
+                "error": "the store record is owned by a newer run",
+            }
+        try:
+            name, _size = attach.download(
+                jobs, item_id, meta,
+                transport=ports.transport, now=ports.clock.now(),
+            )
+        except attach.AttachError as error:
+            return {"kept": False, "error": error.message}
+        return {"kept": True, "name": name}
 
     # The guarantee: this exact invocation (source x content x params — the
     # id) is served from disk free — unless the last attempt failed (a
@@ -358,6 +423,7 @@ def parse(
                 stored_meta["job_id"],
                 cached=True,
                 completed_at=stored_meta.get("completed_at"),
+                copy_info=maybe_keep_copy(),
             )
             return
 
@@ -377,7 +443,7 @@ def parse(
         as_json=as_json,
         endpoint_label=resolved.endpoint_label,
     )
-    emit_summary(data, job_id, cached=False, stored=stored)
+    emit_summary(data, job_id, cached=False, stored=stored, copy_info=maybe_keep_copy())
 
 
 def ensure_parsed(

--- a/src/ade_cli/raster.py
+++ b/src/ade_cli/raster.py
@@ -45,7 +45,10 @@ def crop_box(source: str | None, page: int, box: dict, *, dpi: int):
     if not path.is_file():
         if source.startswith(("http://", "https://")):
             raise CropError(
-                "source_missing", "document was parsed from a URL; no local file"
+                "source_missing",
+                "parsed from a URL — the CLI never had the document bytes "
+                "to crop from; download the file and parse it locally "
+                "(ade parse -d <file>)",
             )
         raise CropError("source_missing", f"{source} no longer exists")
     try:
@@ -138,8 +141,22 @@ def render_source(
     path = Path(source)
     if not path.is_file():
         if source.startswith(("http://", "https://")):
-            return {}, "source unavailable: document was parsed from a URL"
-        return {}, f"source unavailable: {source} no longer exists"
+            # Not an error to fix in place (#169): URL parses never hand
+            # the CLI the document bytes, so there is nothing local to
+            # raster — say why, what still works, and the action that
+            # gets previews. The "source un" prefix is load-bearing:
+            # view.py keys the no-sidecar path off it.
+            return {}, (
+                "source unavailable: parsed from a URL — the CLI never had "
+                "the document bytes to render page previews (markdown, "
+                "elements, and extractions are unaffected). For page "
+                "previews, download the document and parse the local "
+                "file: ade parse -d <file>"
+            )
+        return {}, (
+            f"source unavailable: {source} no longer exists — restore the "
+            "file at that path and re-run `ade view` to render page previews"
+        )
     wanted = pages[:cap] if cap else list(pages)
     try:
         with path.open("rb") as head:

--- a/src/ade_cli/raster.py
+++ b/src/ade_cli/raster.py
@@ -146,12 +146,13 @@ def render_source(
             # raster — say why, what still works, and the action that
             # gets previews. The "source un" prefix is load-bearing:
             # view.py keys the no-sidecar path off it.
+            # Cause + what still works; the id-bearing action (`ade view
+            # <id> --download`) is appended by the view layer, which
+            # holds the item id.
             return {}, (
                 "source unavailable: parsed from a URL — the CLI never had "
                 "the document bytes to render page previews (markdown, "
-                "elements, and extractions are unaffected). For page "
-                "previews, download the document and parse the local "
-                "file: ade parse -d <file>"
+                "elements, and extractions are unaffected)."
             )
         return {}, (
             f"source unavailable: {source} no longer exists — restore the "

--- a/src/ade_cli/shipping.py
+++ b/src/ade_cli/shipping.py
@@ -43,7 +43,7 @@ from typing import Mapping
 
 import httpx
 
-from . import telemetry
+from . import store, telemetry
 from .config import DEFAULT_ENVIRONMENT, ENVIRONMENTS
 from .credentials import stored_credential
 from .filelock import exclusive
@@ -306,7 +306,10 @@ def _maintain(path: Path, home: Path, shipped: set[str]) -> None:
             os.write(fd, b"".join(lines))
         finally:
             os.close(fd)
-        os.replace(tmp, path)
+        # Same transient-sharing-violation retry as the store's atomic
+        # writes (#162): the ledger is one file shared by every
+        # concurrent invocation.
+        store.replace_with_retry(tmp, path)
 
 
 def _rotate(lines: list[bytes]) -> list[bytes]:

--- a/src/ade_cli/store.py
+++ b/src/ade_cli/store.py
@@ -195,7 +195,7 @@ def write_atomic(path: Path, text: str) -> Path:
         f".{path.name}.tmp-{os.getpid()}-{threading.get_ident()}"
     )
     tmp.write_text(text, encoding="utf-8")
-    _replace_with_retry(tmp, path)
+    replace_with_retry(tmp, path)
     return path
 
 
@@ -205,7 +205,7 @@ def write_atomic(path: Path, text: str) -> Path:
 _REPLACE_ATTEMPTS = 10
 
 
-def _replace_with_retry(tmp: Path, path: Path) -> None:
+def replace_with_retry(tmp: Path, path: Path) -> None:
     """``os.replace``, retried briefly with backoff on PermissionError
     (#162). On Windows, MoveFileEx fails with ERROR_ACCESS_DENIED while
     the destination is momentarily open in another process without
@@ -213,7 +213,9 @@ def _replace_with_retry(tmp: Path, path: Path) -> None:
     ``history.js``, so two concurrent invocations race on exactly this
     call. The condition is transient by nature; tens of milliseconds of
     backoff clears it. POSIX renames never fail this way, so the retry
-    path is Windows-only in practice."""
+    path is Windows-only in practice. Shared by every temp-then-replace
+    publisher of a store-shared file (history.js here, the telemetry
+    ledger, the update-check stamp)."""
     delay = 0.01
     for _ in range(_REPLACE_ATTEMPTS - 1):
         try:

--- a/src/ade_cli/update.py
+++ b/src/ade_cli/update.py
@@ -46,6 +46,7 @@ from typing import Mapping, NoReturn
 import httpx
 import typer
 
+from . import store
 from .config import load_config
 from .filelock import exclusive
 from .output import EXIT_FAILED, EXIT_USAGE, JSON_FLAG, emit, exit_with
@@ -601,7 +602,9 @@ def _write_cache(home: Path, *, latest: str | None) -> None:
             json.dumps({"checked_at": time.time(), "latest": latest}),
             encoding="utf-8",
         )
-        os.replace(tmp, home / CACHE_NAME)
+        # Retried like every shared-file publish (#162): concurrent
+        # invocations can race on the one stamp file on Windows.
+        store.replace_with_retry(tmp, home / CACHE_NAME)
     except OSError:
         pass
 

--- a/src/ade_cli/view.py
+++ b/src/ade_cli/view.py
@@ -42,7 +42,7 @@ from pathlib import Path
 
 import typer
 
-from . import elements, evidence, historyjs, items, serve
+from . import attach, elements, evidence, historyjs, items, serve
 from .config import ade_home
 from .crop import DEFAULT_CROP_DPI, crop_element_to_file
 from .history import resolve_or_exit
@@ -180,6 +180,14 @@ def _referencing_extractions(
     return layers
 
 
+def _imagery_source(store: JobStore, bundle: dict) -> str | None:
+    """What this bundle's page imagery renders from: the parse item's
+    recorded source, or its attached copy for URL parses (#169 —
+    `parse --keep-copy` / `view --download`)."""
+    owner = bundle.get("parse_item_id") or bundle["record"]["job_item_id"]
+    return attach.renderable_source(store, owner, bundle["parse_meta"])
+
+
 class BundleError(Exception):
     def __init__(self, kind: str, message: str, hint: str):
         super().__init__(message)
@@ -296,13 +304,15 @@ def _fingerprint(
     *,
     dpi: int,
     pages: str | None,
+    render_from: str | None,
 ) -> str:
     """What the artifact was built from: template, item kind/linkage, parse
     generation, the extraction layers (a new, newly-stale, or removed layer
-    changes the artifact), build params, and the source's identity-by-stat
-    (a moved or edited source must rebuild — page images render from it)."""
+    changes the artifact), build params, and the render source's
+    identity-by-stat (a moved or edited source must rebuild — page images
+    render from it; attaching a URL item's copy moves it too, #169)."""
     meta = bundle["parse_meta"]
-    source = meta.get("source")
+    source = render_from
     path = Path(source) if source else None
     if path is not None and path.is_file():
         stat = path.stat()
@@ -373,12 +383,14 @@ def _write_pages_chunk(
     store.write_text(parse_item_id, _chunk_name(index), js)
 
 
-def _pages_fingerprint(meta: dict, total_pages: int) -> str:
-    """What the sidecar chunks were rendered from: the source's
+def _pages_fingerprint(render_from: str | None, total_pages: int) -> str:
+    """What the sidecar chunks were rendered from: the render source's
     identity-by-stat and the render scheme. Imagery derives from the
     source alone (never the parse generation), so job_id stays out — a
-    --force re-parse of an unchanged file must not re-render every page."""
-    source = meta.get("source")
+    --force re-parse of an unchanged file must not re-render every page.
+    ``render_from`` is the resolved local path (the recorded source, or a
+    URL item's attached copy — #169)."""
+    source = render_from
     path = Path(source) if source else None
     if path is not None and path.is_file():
         stat = path.stat()
@@ -422,7 +434,8 @@ def _ensure_pages_chunks(
     that yields no images stops the sweep — the viewer's placeholders and
     notice explain, and nothing half-written poses as current."""
     total = _chunk_count(len(all_pages))
-    fingerprint = _pages_fingerprint(meta, len(all_pages))
+    render_from = attach.renderable_source(store, parse_item_id, meta)
+    fingerprint = _pages_fingerprint(render_from, len(all_pages))
     written = 0
     for index in range(1, total + 1):
         if only is not None and index not in only:
@@ -430,9 +443,7 @@ def _ensure_pages_chunks(
         if _chunk_current(store, parse_item_id, index, fingerprint):
             continue
         pages = all_pages[(index - 1) * PAGES_CHUNK : index * PAGES_CHUNK]
-        images, _note = render_source(
-            meta.get("source"), pages, dpi=DEFAULT_DPI, cap=0
-        )
+        images, _note = render_source(render_from, pages, dpi=DEFAULT_DPI, cap=0)
         if not images:
             break
         _write_pages_chunk(store, parse_item_id, index, total, images, fingerprint)
@@ -447,7 +458,8 @@ def _write_free_chunks(
     images — write every chunk they fully cover for free; the background
     builder renders the rest."""
     total = _chunk_count(len(all_pages))
-    fingerprint = _pages_fingerprint(meta, len(all_pages))
+    render_from = attach.renderable_source(store, item_id, meta)
+    fingerprint = _pages_fingerprint(render_from, len(all_pages))
     for index in range(1, total + 1):
         pages = all_pages[(index - 1) * PAGES_CHUNK : index * PAGES_CHUNK]
         chunk_images = {p: images[p] for p in pages if p in images}
@@ -531,6 +543,7 @@ def _build(
     pages_spec: str | None,
     fingerprint: str,
     built_at: str,
+    render_from: str | None,
 ) -> tuple[Path, int, str | None]:
     """Stamp the template with this job item's data; returns
     ``(path, pages embedded, degradation note)``."""
@@ -575,7 +588,7 @@ def _build(
             images, note = {}, None
         else:
             images, note = render_source(
-                meta.get("source"), wanted, dpi=dpi, cap=PAGE_CAP
+                render_from, wanted, dpi=dpi, cap=PAGE_CAP
             )
             # A missing/URL source is a stable input (its reappearance
             # changes the fingerprint), but a render *error* is transient —
@@ -605,7 +618,7 @@ def _build(
         # Emit only when the head chunk actually exists — a source that
         # rendered nothing can't produce the rest either.
         if _chunk_current(
-            store, owner, 1, _pages_fingerprint(meta, len(all_pages))
+            store, owner, 1, _pages_fingerprint(render_from, len(all_pages))
         ):
             page_chunks = _page_chunks_payload(
                 all_pages, src_prefix=f"../{owner}/"
@@ -613,6 +626,12 @@ def _build(
             pages_key = owner
         else:
             page_chunks, pages_key = [], None
+            if render_from and render_from.startswith(("http://", "https://")):
+                # A URL parse without an attached copy can never render
+                # the sidecars this light artifact loads from — surface
+                # the same cause + action banner the parse viewer gets
+                # (#169) instead of bare placeholders.
+                _, note = render_source(render_from, [], dpi=DEFAULT_DPI, cap=0)
     else:
         page_chunks = _page_chunks_payload(all_pages, src_prefix="")
         pages_key = item_id
@@ -621,6 +640,28 @@ def _build(
     # themselves — so that case informs the CLI summary but never the
     # banner (a 235-page doc must not open under a warning).
     banner_note = note
+    # A URL item's missing preview gets the id-bearing action (#169): the
+    # cause comes from the raster layer; the command that fixes it needs
+    # the item id, which only this layer holds.
+    if note and note.startswith("source unavailable: parsed from a URL"):
+        owner_id = bundle.get("parse_item_id") or item_id
+        action = (
+            f" Fetch them with `ade view {items.short_id(store, owner_id)} "
+            "--download`, or keep a copy at parse time with "
+            "`parse --keep-copy`."
+        )
+        note += action
+        banner_note = note
+    # Renders from an attached copy carry the unverifiable-bytes caveat —
+    # the CLI never saw what the server parsed (#169).
+    copy_caveat = attach.caveat(
+        store, bundle.get("parse_item_id") or item_id, meta
+    )
+    if copy_caveat and (images or page_chunks):
+        note = copy_caveat if note is None else f"{note}; {copy_caveat}"
+        banner_note = (
+            copy_caveat if banner_note is None else f"{banner_note}; {copy_caveat}"
+        )
     if page_chunks and note and "not embedded (cap" in note:
         deferred_pages = [p for p in all_pages if p not in images]
         note = (
@@ -695,7 +736,10 @@ def ensure_built(
     behind the foreground command and the background builder. Raises
     BundleError when the item has nothing renderable."""
     bundle = _load_bundle(store, item_id)
-    fingerprint = _fingerprint(template, bundle, dpi=dpi, pages=pages)
+    render_from = _imagery_source(store, bundle)
+    fingerprint = _fingerprint(
+        template, bundle, dpi=dpi, pages=pages, render_from=render_from
+    )
     path = store.item_dir(item_id) / ARTIFACT
     if _stored_fingerprint(path) == fingerprint:
         return path, False, None, None
@@ -711,6 +755,7 @@ def ensure_built(
         pages_spec=pages,
         fingerprint=fingerprint,
         built_at=built_at,
+        render_from=render_from,
     )
     return path, True, embedded, note
 
@@ -773,13 +818,14 @@ def _needs_chunks(store: JobStore, record: dict) -> bool:
     if not pages:
         return False
     meta = store.read_json(record["job_item_id"], "meta.json") or {}
-    source = meta.get("source") or ""
+    source = attach.renderable_source(store, record["job_item_id"], meta) or ""
     if source.startswith(("http://", "https://")) or not Path(source).is_file():
-        # Nothing local to render from (URL source, or the file is gone):
-        # chunks can never materialize, and answering True here would
-        # detach a futile builder on every single view run.
+        # Nothing local to render from (URL source without an attached
+        # copy, or the file is gone): chunks can never materialize, and
+        # answering True here would detach a futile builder on every
+        # single view run.
         return False
-    fingerprint = _pages_fingerprint(meta, pages)
+    fingerprint = _pages_fingerprint(source, pages)
     return any(
         not _chunk_current(store, record["job_item_id"], index, fingerprint)
         for index in range(1, _chunk_count(pages) + 1)
@@ -931,6 +977,15 @@ def view(
     pages: str | None = typer.Option(
         None, "--pages", help="Pages to embed images for, 1-indexed, e.g. '1,3-5'."
     ),
+    download: bool = typer.Option(
+        False, "--download",
+        help="URL-parsed items: fetch the document from its recorded URL "
+        "into the job item and render page previews from that copy — "
+        "the parse itself never gives the CLI the bytes (#169). Plain "
+        "HTTP, no API credits; the copy is unverified against the "
+        "parsed run. Also works on an extract item id (fetches into "
+        "its referenced parse item).",
+    ),
     no_sidebar_sync: bool = typer.Option(
         False, "--no-sidebar-sync",
         help="Skip the background build of missing sibling viewers.",
@@ -1048,6 +1103,72 @@ def view(
             )
 
     record = items.item_record(store, item_id)
+
+    # --download (#169): attach the URL document's bytes to the imagery
+    # owner (the item itself, or a referencing extract's parse item)
+    # BEFORE the bundle loads, so this same run renders from the copy.
+    download_line = ""
+    downloaded: bool | None = None
+    if download:
+        if record["kind"] == "parse":
+            owner_id = item_id
+        else:
+            ref = record.get("parse") or {}
+            owner_id = (
+                ref.get("job_item_id") if not ref.get("missing") else None
+            )
+        owner_meta = (
+            store.read_json(owner_id, "meta.json") if owner_id else None
+        )
+        if not owner_id or not attach.is_url_source(owner_meta):
+            message = (
+                f"Job item {item_id} has no URL source to download: "
+                "--download applies to items parsed from --document-url "
+                "(local parses render previews from their file directly)."
+            )
+            exit_with(
+                {
+                    "error": "not_a_url_source",
+                    "job_item_id": item_id,
+                    "message": message,
+                },
+                message,
+                as_json=as_json,
+                code=EXIT_USAGE,
+            )
+        already = attach.attached_file(store, owner_id, owner_meta)
+        if already is not None:
+            downloaded = False
+            download_line = (
+                f"\n  download: copy already attached ({already.name}); "
+                "previews render from it"
+            )
+        else:
+            try:
+                name, size = attach.download(
+                    store,
+                    owner_id,
+                    owner_meta or {},
+                    transport=ports.transport,
+                    now=ports.clock.now(),
+                )
+            except attach.AttachError as error:
+                exit_with(
+                    {
+                        "error": error.kind,
+                        "job_item_id": owner_id,
+                        "message": error.message,
+                    },
+                    error.message,
+                    as_json=as_json,
+                    code=EXIT_FAILED,
+                )
+            downloaded = True
+            download_line = (
+                f"\n  download: fetched {name} ({size:,} bytes) into job "
+                f"item {owner_id}"
+            )
+
     try:
         bundle = _load_bundle(store, item_id)
     except BundleError as error:
@@ -1090,11 +1211,23 @@ def view(
                 source_item_id=bundle.get("parse_item_id") or item_id,
             )
         except CropError as error:
+            message = error.message
+            if "parsed from a URL" in message:
+                owner_id = bundle.get("parse_item_id") or item_id
+                message += (
+                    f" Fetch it with `ade view {owner_id} --download`, "
+                    "then re-run."
+                )
+                tail = ""
+            else:
+                tail = (
+                    " (a crop is never served from stale imagery; restore "
+                    "the source and re-run)"
+                )
             exit_with(
                 {"error": error.kind, "job_item_id": item_id,
-                 "element_id": element_id, "message": error.message},
-                f"Cannot crop {element_id}: {error.message} (a crop is never "
-                "served from stale imagery; restore the source and re-run).",
+                 "element_id": element_id, "message": message},
+                f"Cannot crop {element_id}: {message}{tail}.",
                 as_json=as_json,
                 code=EXIT_FAILED,
             )
@@ -1172,7 +1305,10 @@ def view(
 
     page_dpi = dpi if dpi is not None else DEFAULT_DPI
     template = _template()
-    fingerprint = _fingerprint(template, bundle, dpi=page_dpi, pages=pages)
+    render_from = _imagery_source(store, bundle)
+    fingerprint = _fingerprint(
+        template, bundle, dpi=page_dpi, pages=pages, render_from=render_from
+    )
     path = store.item_dir(item_id) / ARTIFACT
     built = _stored_fingerprint(path) != fingerprint
     embedded: int | None = None
@@ -1190,6 +1326,7 @@ def view(
             pages_spec=pages,
             fingerprint=fingerprint,
             built_at=built_at,
+            render_from=render_from,
         )
 
     # The sidebar contract: every run refreshes history.js from a fresh
@@ -1230,6 +1367,8 @@ def view(
         "history_items": len(history_records),
         "sidebar_sync": syncing,
     }
+    if downloaded is not None:
+        payload["downloaded"] = downloaded
     hint = f"ade view {items.short_id(store, item_id)} --open" + (
         f" --element-id {element_id}" if element_id else ""
     )
@@ -1244,6 +1383,7 @@ def view(
     human = (
         f"Viewer for job item {item_id} ({record['kind']}) -> {tilde(path)} "
         + ("(built)" if built else "(up to date)")
+        + download_line
         + (f"\n  note: {note}" if note else "")
         + (
             f"\n  serve: {serve_error} — falling back to file://"

--- a/src/ade_cli/view.py
+++ b/src/ade_cli/view.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -785,6 +786,23 @@ def _needs_chunks(store: JobStore, record: dict) -> bool:
     )
 
 
+def _detach_kwargs() -> dict:
+    """How a background child actually detaches, per platform. POSIX:
+    ``start_new_session`` (its own session, immune to the parent's
+    signals). Windows silently *ignores* ``start_new_session``, so the
+    "detached" child used to stay attached to the parent console — a
+    Ctrl-C or a closed terminal killed the builder mid-build. DETACHED
+    (no console at all — stdio is DEVNULL anyway) plus a new process
+    group makes the detachment real there."""
+    if os.name == "nt":  # pragma: no cover - exercised on Windows only
+        return {
+            "creationflags": (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+            )
+        }
+    return {"start_new_session": True}
+
+
 def _spawn_builder(store: JobStore, records: list[dict]) -> bool:
     """Detach the background builder when any sibling viewer — or any
     parse item's page-imagery chunks — is missing. The child re-execs
@@ -806,7 +824,7 @@ def _spawn_builder(store: JobStore, records: list[dict]) -> bool:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
-        start_new_session=True,
+        **_detach_kwargs(),
     )
     return True
 
@@ -821,7 +839,7 @@ def _spawn_server(port: int) -> None:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
-        start_new_session=True,
+        **_detach_kwargs(),
     )
 
 
@@ -830,8 +848,6 @@ def _sync_viewers(store: JobStore, now_fn) -> dict:
     with our pid — a dead claim is ignored by the scan and overwritten
     here), build, unclaim, rewriting history.js around every transition so
     open sidebars see building → built without a rebuild."""
-    import os
-
     template = _template()
     built, skipped, failed = [], [], []
     chunks = 0

--- a/src/ade_cli/view.py
+++ b/src/ade_cli/view.py
@@ -55,7 +55,7 @@ ARTIFACT = "view.html"
 # Bump when the Python-side bundle shaping changes (the fields the template
 # receives): the template hash alone can't see it, and a stale artifact
 # would otherwise be reused forever (its item identity never moves).
-BUNDLE_REVISION = 4
+BUNDLE_REVISION = 5
 DEFAULT_DPI = 120
 # Embed posture: modest dpi, first PAGE_CAP pages inline (--pages picks a
 # different window); everything else lazy-loads from the sidecar chunks.
@@ -652,16 +652,16 @@ def _build(
         )
         note += action
         banner_note = note
-    # Renders from an attached copy carry the unverifiable-bytes caveat —
-    # the CLI never saw what the server parsed (#169).
+    # Renders from an attached copy carry the unverifiable-bytes caveat
+    # (#169) — short and actionable in the CLI note; in the artifact it
+    # renders as a compact banner line whose hover carries the full
+    # story, like the stale badge.
     copy_caveat = attach.caveat(
         store, bundle.get("parse_item_id") or item_id, meta
     )
-    if copy_caveat and (images or page_chunks):
+    show_caveat = bool(copy_caveat and (images or page_chunks))
+    if show_caveat:
         note = copy_caveat if note is None else f"{note}; {copy_caveat}"
-        banner_note = (
-            copy_caveat if banner_note is None else f"{banner_note}; {copy_caveat}"
-        )
     if page_chunks and note and "not embedded (cap" in note:
         deferred_pages = [p for p in all_pages if p not in images]
         note = (
@@ -711,6 +711,14 @@ def _build(
         "markdown": markdown_text,
         "raw_response": raw_response,
         "extractions": bundle["extractions"],
+        "copy_caveat": (
+            {
+                "text": "page previews render from a downloaded copy of the URL",
+                "detail": attach.CAVEAT_DETAIL,
+            }
+            if show_caveat
+            else None
+        ),
     }
     for page in payload["pages"]:
         page["image"] = page.pop("data_uri")

--- a/src/ade_cli/view.py
+++ b/src/ade_cli/view.py
@@ -1261,8 +1261,12 @@ def view(
         ]
         meta = bundle["parse_meta"]
         # Same drift rule as the standalone `crop` (issue #119): a changed
-        # source still renders, with the mismatch said out loud.
-        drift = source_drift_note(meta)
+        # source still renders, with the mismatch said out loud. URL items
+        # have no drift check; a crop from their attached copy carries the
+        # unverified-bytes caveat instead — mirroring standalone crop.
+        drift = source_drift_note(meta) or attach.caveat(
+            store, bundle.get("parse_item_id") or item_id, meta
+        )
         payload = {
             "job_item_id": item_id,
             "source_name": Path(meta["source"]).name if meta.get("source") else item_id,

--- a/src/ade_cli/view_template.html
+++ b/src/ade_cli/view_template.html
@@ -190,6 +190,9 @@
   /* Stale extraction mark: amber like .badge.stale, cursor invites the
      hover tooltip that explains it. */
   .hb-stale { color: #a15c07; cursor: help; }
+  /* Attached-copy caveat in the note banner: dotted underline invites
+     the hover tooltip that carries the full story. */
+  .copy-caveat { cursor: help; text-decoration: underline dotted; text-underline-offset: 3px; }
   .hb-empty { padding: 16px; font-size: 12px; color: var(--text-tertiary); text-align: center; }
   /* Collapse/expand — VUI GlobalSidebarV3: an IconSidebar ghost button in
      the header; collapsed is a 52px rail (width animates 300ms
@@ -942,6 +945,18 @@ function renderMarkdown(src, target) {
     const banner = document.getElementById("notebanner");
     banner.hidden = false;
     banner.textContent = DATA.note;
+  }
+  if (DATA.copy_caveat) {
+    // Attached-copy caveat (#169): a calm one-liner in the banner; the
+    // full story rides on hover, like the stale badge's tooltip.
+    const banner = document.getElementById("notebanner");
+    if (banner.textContent) banner.appendChild(document.createTextNode("  ·  "));
+    const caveat = document.createElement("span");
+    caveat.className = "copy-caveat";
+    caveat.textContent = DATA.copy_caveat.text;
+    caveat.title = DATA.copy_caveat.detail;
+    banner.hidden = false;
+    banner.appendChild(caveat);
   }
   // Workflow pills — Parse always; Extract only when the store holds
   // extractions (user decision; VUI gates pills on enabledTools,

--- a/src/ade_cli/view_template.html
+++ b/src/ade_cli/view_template.html
@@ -1141,9 +1141,12 @@ function boxNode(id, type, box, cls, label) {
       placeholder.textContent = "page " + p.page + " — loading imagery…";
       deferred.set(p.page, placeholder);
     } else {
+      // No image and no sidecar to load one from: the banner (DATA.note)
+      // carries the why and the fix (#169 — URL parses have no local
+      // bytes to render); the per-page line just points at it.
       el("div", "placeholder", page).textContent =
         "page " + p.page + (p.status === "failed" ? " — failed to parse"
-          : " — source unavailable (boxes approximate)");
+          : " — no page image (see the notice above)");
     }
     for (const e of ELS) {
       if (e.page !== p.page) continue;

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -596,3 +596,22 @@ def test_single_crop_output_path_creates_missing_parents(cli, parsed, tmp_path):
     assert out.is_file()
     assert payload["crops"][0]["path"] == str(out)
     assert payload["directory"] == str(out.parent)
+
+
+def test_crop_of_a_url_parsed_item_names_the_remediation(cli):
+    """#169's crop face: a URL parse has no local bytes to crop from — the
+    error must say why and how to get crops, not claim a file vanished."""
+    cli.transport.respond(202, {"job_id": "job-0001"})
+    cli.transport.respond(200, completed_job(rich_parse_response()))
+    parsed = cli.invoke(
+        "parse", "--document-url", "https://example.com/doc.pdf",
+        "--json", env=AUTH_ENV,
+    )
+    assert parsed.exit_code == 0, parsed.stdout
+    item_id = json.loads(parsed.stdout)["job_item_id"]
+
+    payload = crop_json(cli, item_id, "--element-id", "text-0", exit_code=1)
+
+    assert payload["error"] == "source_missing"
+    assert "parsed from a URL" in payload["message"]
+    assert "ade parse -d" in payload["message"]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -794,11 +794,13 @@ def test_extract_summary_advertises_store_dir_and_next_commands(
         )
         line = summary_next_line(result.stdout)
         assert "ade history list" in line
-        # The viewer hint names the referenced parse item (its viewer
-        # renders this extraction as a layer), by a runnable short prefix.
+        # The viewer hint names the extract item's OWN id (#170): that is
+        # the only viewer that renders this extraction — the parse item's
+        # viewer deliberately holds parse only.
         assert "ade view " in line and "--open" in line
         ref = line.split("ade view ", 1)[1].split()[0]
-        assert parse_id.startswith(ref)
+        assert extract_dir.name.startswith(ref)
+        assert not parse_id.startswith(ref)
 
 
 def test_extract_json_carries_the_contract_fields(cli, document, schema_file):
@@ -920,9 +922,10 @@ def test_partial_state_survives_the_cached_path_and_listings(
     assert '"warnings": 1' in sidebar
 
 
-def test_markdown_extraction_next_hint_never_points_at_the_viewer(cli, tmp_path):
-    # A bring-your-own-markdown item has no parse and never will: hinting at
-    # `view` would hint at an error.
+def test_markdown_extraction_next_hint_points_at_its_own_viewer(cli, tmp_path):
+    # A bring-your-own-markdown item owns a viewer too (the markdown pane
+    # alone, opening on the Extract tab) — the hint names its own id
+    # (#170), same as the parse-backed form.
     md = tmp_path / "notes.md"
     md.write_text("# Notes\nTotal: €42\n")
     cli.transport.respond(202, {"job_id": "extract-0001"})
@@ -933,9 +936,11 @@ def test_markdown_extraction_next_hint_never_points_at_the_viewer(cli, tmp_path)
     )
 
     assert result.exit_code == 0, result.stdout
+    (extract_dir,) = extract_item_dirs(cli)
     line = summary_next_line(result.stdout)
     assert "ade history list" in line
-    assert "ade view" not in line
+    ref = line.split("ade view ", 1)[1].split()[0]
+    assert extract_dir.name.startswith(ref)
 
 
 def test_extract_summary_and_payload_name_the_server_run_never_job(

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -821,9 +821,12 @@ def test_history_list_caps_at_the_newest_100_by_default(cli):
     assert tail[0]["job_item_id"] == f"{20:016x}"
     assert tail[-1]["job_item_id"] == f"{119:016x}"
 
-    # The human rendering carries the footer inline.
+    # The human rendering LEADS with the notice — a reader knows the view
+    # is capped before scanning it — and it names the way out.
     human = cli.invoke("history", "list")
-    assert "newest 100 of 120" in human.stdout
+    first_line = human.stdout.splitlines()[0]
+    assert "newest 100 of 120" in first_line
+    assert "ade history list --all" in first_line
 
 
 def test_a_capped_listing_never_drops_a_child_whose_parent_fell_outside(cli):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -73,17 +73,28 @@ def history_js_items(cli):
     return payload["items"]
 
 
-def test_history_js_lists_latest_submission_first(cli, document):
-    """The sidebar renders history.js in file order; the newest run is what
-    the user just did, so it leads. `history list` keeps oldest-first."""
+def test_history_lists_newest_submission_first_by_default(cli, document):
+    """Listings lead with the run the user just did — the same order the
+    sidebar has always used; --asc restores the chronological read."""
     first = parse_file(cli, document)
     cli.clock.sleep(60)  # the second run submits later
     second = parse_file(cli, document, "--tier", "standard", job_id="job-0002")
 
     result = cli.invoke("history", "list", "--json")
-
-    assert [r["job_item_id"] for r in json.loads(result.stdout)] == [first, second]
+    assert [r["job_item_id"] for r in json.loads(result.stdout)] == [second, first]
     assert [item["id"] for item in history_js_items(cli)] == [second, first]
+
+    # --asc: oldest first, on both the subcommand and the bare default.
+    ascending = cli.invoke("history", "list", "--asc", "--json")
+    assert [r["job_item_id"] for r in json.loads(ascending.stdout)] == [first, second]
+    bare = cli.invoke("history", "--asc", "--json")
+    assert [r["job_item_id"] for r in json.loads(bare.stdout)] == [first, second]
+
+    # The human rendering follows the same order as --json.
+    human = cli.invoke("history", "list")
+    lines = [ln for ln in human.stdout.splitlines() if ln.strip()]
+    assert lines[0].startswith(second)
+    assert lines[1].startswith(first)
 
 
 def test_bare_history_defaults_to_list(cli, document):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -760,3 +760,82 @@ def test_extract_record_parse_linkage_uses_run_terminology(
         (cli.home / "jobs" / extract_id / "parse/ref.json").read_text()
     )
     assert ref == {"job_item_id": parse_id, "parse_job_id": "job-0001"}
+
+
+# --- the listing cap: newest 100 by default ---------------------------------
+
+
+def seed_minimal_item(cli, item_id, submitted_at, *, parent=None):
+    """A minimal on-disk item (meta + ticket), fast enough to seed the
+    store past the listing cap without 100+ transport round-trips."""
+    item = cli.home / "jobs" / item_id
+    item.mkdir(parents=True, exist_ok=True)
+    (item / "meta.json").write_text(json.dumps({
+        "job_item_id": item_id,
+        "kind": "extract" if parent else "parse",
+        "state": "extracted" if parent else "parsed",
+        "source": f"/tmp/{item_id}.pdf",
+        "job_id": f"run-{item_id}",
+        "params": {"model": "dpt-3-pro-latest", "options": {}, "tier": "priority"},
+        "completed_at": submitted_at + 1,
+    }))
+    (item / "job.json").write_text(json.dumps({
+        "v": 1, "kind": "extract" if parent else "parse",
+        "job_id": f"run-{item_id}", "state": "completed",
+        "submitted_at": submitted_at,
+    }))
+    if parent:
+        (item / "parse").mkdir(exist_ok=True)
+        (item / "parse" / "ref.json").write_text(
+            json.dumps({"job_item_id": parent, "parse_job_id": f"run-{parent}"})
+        )
+    return item_id
+
+
+def test_history_list_caps_at_the_newest_100_by_default(cli):
+    for n in range(120):
+        seed_minimal_item(cli, f"{n:016x}", 1_000_000.0 + n)
+
+    result = cli.invoke("history", "list", "--json")
+    listed = json.loads(result.stdout)
+    assert len(listed) == 100
+    # The newest 100: items 20..119, newest first.
+    assert listed[0]["job_item_id"] == f"{119:016x}"
+    assert listed[-1]["job_item_id"] == f"{20:016x}"
+    # The cap is said out loud — on stderr, never in the payload.
+    assert "newest 100 of 120" in result.stderr
+    assert "--all" in result.stderr
+
+    # --limit and --all adjust it; small stores never see a footer.
+    five = json.loads(cli.invoke("history", "list", "--limit", "5", "--json").stdout)
+    assert [r["job_item_id"] for r in five] == [
+        f"{n:016x}" for n in range(119, 114, -1)
+    ]
+    everything = cli.invoke("history", "list", "--all", "--json")
+    assert len(json.loads(everything.stdout)) == 120
+    assert everything.stderr.strip() == ""
+
+    # --asc under the cap is a chronological tail: the SAME newest set,
+    # presented oldest first.
+    tail = json.loads(cli.invoke("history", "list", "--asc", "--json").stdout)
+    assert tail[0]["job_item_id"] == f"{20:016x}"
+    assert tail[-1]["job_item_id"] == f"{119:016x}"
+
+    # The human rendering carries the footer inline.
+    human = cli.invoke("history", "list")
+    assert "newest 100 of 120" in human.stdout
+
+
+def test_a_capped_listing_never_drops_a_child_whose_parent_fell_outside(cli):
+    """--limit keeps the newest N records; an extract whose parse fell
+    outside the window still renders — as its own top row — instead of
+    silently vanishing from the human listing."""
+    parse_id = seed_minimal_item(cli, "aa" * 8, 1_000_000.0)
+    extract_id = seed_minimal_item(cli, "bb" * 8, 1_000_100.0, parent=parse_id)
+
+    result = cli.invoke("history", "list", "--limit", "1", "--json")
+    listed = json.loads(result.stdout)
+    assert [r["job_item_id"] for r in listed] == [extract_id]
+
+    human = cli.invoke("history", "list", "--limit", "1")
+    assert extract_id in human.stdout  # rendered, not dropped by grouping

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -681,3 +681,87 @@ def test_failed_human_text_names_the_job_item_id(cli, document):
 
     assert result.exit_code == 1
     assert f"job item {item_dir(cli, document).name}" in result.stdout
+
+
+def test_keep_copy_downloads_the_url_document_into_the_job_item(cli):
+    """#169: --keep-copy fetches the document at parse time — while the
+    (often pre-signed) URL still works — so previews and crops render
+    locally ever after. Plain HTTP; the parse's own billing is untouched."""
+    import httpx
+
+    cli.transport.respond(202, {"job_id": JOB_ID})
+    cli.transport.respond(200, completed_job())
+    pdf = b"%PDF-1.4 tiny fixture"
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=pdf))
+
+    result = cli.invoke(
+        "parse", "--document-url", "https://example.com/inv.pdf",
+        "--keep-copy", "--json", env=AUTH_ENV,
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["kept_copy"] is True
+    item_dir_ = cli.home / "jobs" / payload["job_item_id"]
+    assert (item_dir_ / "document.pdf").read_bytes() == pdf
+    meta = json.loads((item_dir_ / "meta.json").read_text())
+    assert meta["attached_source"] == "document.pdf"
+    assert meta["source"] == "https://example.com/inv.pdf"
+    assert str(cli.transport.requests[-1].url) == "https://example.com/inv.pdf"
+
+
+def test_keep_copy_failure_warns_but_the_parse_succeeds(cli):
+    import httpx
+
+    cli.transport.respond(202, {"job_id": JOB_ID})
+    cli.transport.respond(200, completed_job())
+    cli.transport.respond_with(lambda req: httpx.Response(403, content=b"expired"))
+
+    result = cli.invoke(
+        "parse", "--document-url", "https://example.com/inv.pdf",
+        "--keep-copy", "--json", env=AUTH_ENV,
+    )
+
+    assert result.exit_code == 0, result.stdout  # the billable work succeeded
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "parsed"
+    assert payload["kept_copy"] is False
+    assert "expire" in payload["keep_copy_error"]
+
+
+def test_keep_copy_requires_a_url_source(cli, document):
+    result = cli.invoke(
+        "parse", "-d", str(document), "--keep-copy", "--json", env=AUTH_ENV
+    )
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["error"] == "keep_copy_local_source"
+    assert cli.transport.requests == []
+
+
+def test_keep_copy_on_a_cached_hit_attaches_late(cli):
+    """A URL item parsed without --keep-copy can pick the copy up on a
+    later (free, cached) re-run — no re-parse needed."""
+    import httpx
+
+    cli.transport.respond(202, {"job_id": JOB_ID})
+    cli.transport.respond(200, completed_job())
+    first = cli.invoke(
+        "parse", "--document-url", "https://example.com/inv.pdf",
+        "--json", env=AUTH_ENV,
+    )
+    assert first.exit_code == 0
+
+    pdf = b"%PDF-1.4 tiny fixture"
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=pdf))
+    result = cli.invoke(
+        "parse", "--document-url", "https://example.com/inv.pdf",
+        "--keep-copy", "--json", env=AUTH_ENV,
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["cached"] is True  # no re-parse, no new bill
+    assert payload["kept_copy"] is True
+    item_dir_ = cli.home / "jobs" / payload["job_item_id"]
+    assert (item_dir_ / "document.pdf").read_bytes() == pdf

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -656,3 +656,28 @@ def test_pending_payload_names_the_run_never_job(cli, document):
         "run_id": JOB_ID,
         "job_item_id": item_dir(cli, document).name,
     }
+
+
+def test_pending_human_text_names_the_job_item_id(cli, document):
+    """#167: the pending message is where a --wait 0 user learns the id
+    every follow-up command takes — it must name the job item, not only
+    the run."""
+    cli.transport.respond(202, {"job_id": JOB_ID})
+
+    result = cli.invoke("parse", "-d", str(document), "--wait", "0", env=AUTH_ENV)
+
+    assert result.exit_code == 3
+    assert JOB_ID in result.stdout
+    assert f"job item {item_dir(cli, document).name}" in result.stdout
+
+
+def test_failed_human_text_names_the_job_item_id(cli, document):
+    cli.transport.respond(202, {"job_id": JOB_ID})
+    cli.transport.respond(
+        200, job_payload("failed", failure_reason="scrambled bytes")
+    )
+
+    result = cli.invoke("parse", "-d", str(document), env=AUTH_ENV)
+
+    assert result.exit_code == 1
+    assert f"job item {item_dir(cli, document).name}" in result.stdout

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1145,8 +1145,18 @@ def test_view_download_attaches_the_url_document_and_renders(cli):
     assert payload["downloaded"] is True
     assert payload["built"] is True
     assert payload["pages_embedded"] == 2  # previews actually rendered
-    assert "downloaded copy" in payload["note"]  # the caveat
+    # The CLI note carries the short, actionable caveat...
+    assert "downloaded copy" in payload["note"]
+    assert "re-parse the downloaded file" in payload["note"]
     assert "parsed from a URL" not in payload["note"]  # gap closed
+    # ...and the artifact splits it: a calm banner line plus the full
+    # story on hover (like the stale badge).
+    caveat = embedded_data(cli, item_id)["copy_caveat"]
+    assert caveat["text"] == (
+        "page previews render from a downloaded copy of the URL"
+    )
+    assert "almost certainly identical" in caveat["detail"]
+    assert "ade parse -d" in caveat["detail"]
     copy = cli.home / "jobs" / item_id / "document.pdf"
     assert copy.read_bytes() == pdf
     meta = json.loads((cli.home / "jobs" / item_id / "meta.json").read_text())

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1204,3 +1204,63 @@ def test_view_download_refuses_a_local_source_item(cli, parsed):
 
     assert payload["error"] == "not_a_url_source"
     assert cli.transport.requests == []  # nothing fetched
+
+
+def test_download_rejects_an_oversized_body_mid_stream(cli, monkeypatch):
+    """The attach cap fires while streaming (Copilot review on #173): a
+    wrong URL is rejected as soon as the cap is crossed, the temp file is
+    cleaned up, and nothing is attached."""
+    import httpx
+
+    from ade_cli import attach
+
+    monkeypatch.setattr(attach, "MAX_COPY_BYTES", 64)
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=b"x" * 200))
+
+    payload = view_json(cli, item_id, "--download", exit_code=1)
+
+    assert payload["error"] == "download_failed"
+    assert "attach cap" in payload["message"]
+    item_dir = cli.home / "jobs" / item_id
+    assert not (item_dir / "document.pdf").exists()
+    assert not list(item_dir.glob(".document.pdf.tmp-*"))  # temp cleaned up
+
+
+def test_download_rejects_a_declared_oversize_before_reading(cli, monkeypatch):
+    import httpx
+
+    from ade_cli import attach
+
+    monkeypatch.setattr(attach, "MAX_COPY_BYTES", 64)
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    cli.transport.respond_with(
+        lambda req: httpx.Response(
+            200, content=b"x" * 200, headers={"content-length": "200"}
+        )
+    )
+
+    payload = view_json(cli, item_id, "--download", exit_code=1)
+
+    assert payload["error"] == "download_failed"
+    assert "declares" in payload["message"]  # rejected up front
+
+
+def test_view_crop_from_an_attached_copy_carries_the_caveat(cli):
+    """`view --crop` mirrors standalone crop (Copilot review on #173): a
+    crop rendered from the downloaded copy carries the unverified-bytes
+    caveat as its warning."""
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=_pdf_bytes()))
+    view_json(cli, item_id, "--download")
+
+    result = cli.invoke(
+        "view", item_id, "--element-id", "text-0", "--crop", "--json"
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "cropped"
+    assert "downloaded copy" in payload["warning"]

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1105,10 +1105,92 @@ def test_url_parsed_item_note_explains_the_missing_preview_and_the_fix(cli):
     assert payload["built"] is True
     assert payload["pages_embedded"] == 0
     assert "parsed from a URL" in payload["note"]
-    assert "ade parse -d" in payload["note"]  # the remediation
+    assert "--download" in payload["note"]  # the id-bearing action
+    assert item_id[:8] in payload["note"]
+    assert "--keep-copy" in payload["note"]  # the parse-time alternative
     assert "unaffected" in payload["note"]  # what still works
     # The artifact carries the same story: banner note + placeholders
     # that point at it, and no lazy-load map that could spin forever.
     data = embedded_data(cli, item_id)
     assert "parsed from a URL" in data["note"]
     assert data["page_chunks"] == []
+
+
+def _pdf_bytes(pages=2):
+    import io
+
+    import pypdfium2 as pdfium
+
+    doc = pdfium.PdfDocument.new()
+    for _ in range(pages):
+        doc.new_page(612, 792)
+    buffer = io.BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()
+
+
+def test_view_download_attaches_the_url_document_and_renders(cli):
+    """#169: `view --download` fetches the URL document into the job item
+    and the SAME run renders page previews from the copy — with the
+    unverified-bytes caveat, since the CLI never saw what the server
+    parsed."""
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    pdf = _pdf_bytes()
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=pdf))
+
+    payload = view_json(cli, item_id, "--download")
+
+    assert payload["downloaded"] is True
+    assert payload["built"] is True
+    assert payload["pages_embedded"] == 2  # previews actually rendered
+    assert "downloaded copy" in payload["note"]  # the caveat
+    assert "parsed from a URL" not in payload["note"]  # gap closed
+    copy = cli.home / "jobs" / item_id / "document.pdf"
+    assert copy.read_bytes() == pdf
+    meta = json.loads((cli.home / "jobs" / item_id / "meta.json").read_text())
+    assert meta["attached_source"] == "document.pdf"
+    assert meta["source"] == "https://example.com/doc.pdf"  # provenance kept
+    fetched = cli.transport.requests[-1]
+    assert str(fetched.url) == "https://example.com/doc.pdf"
+
+
+def test_view_download_is_idempotent(cli):
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=_pdf_bytes()))
+    view_json(cli, item_id, "--download")
+    seen = len(cli.transport.requests)
+
+    payload = view_json(cli, item_id, "--download")
+
+    assert payload["downloaded"] is False  # already attached, no re-fetch
+    assert len(cli.transport.requests) == seen
+    assert payload["built"] is False  # the attach didn't move the fingerprint
+    # The caveat lives in the already-built artifact's banner.
+    assert "downloaded copy" in artifact(cli, item_id)
+
+
+def test_view_download_reports_an_expired_url(cli):
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    cli.transport.respond_with(lambda req: httpx.Response(403, content=b"denied"))
+
+    payload = view_json(cli, item_id, "--download", exit_code=1)
+
+    assert payload["error"] == "download_failed"
+    assert "expire" in payload["message"]  # pre-signed links: the expected cause
+    assert "ade parse -d" in payload["message"]  # the fallback action
+    assert not (cli.home / "jobs" / item_id / "document.pdf").exists()
+
+
+def test_view_download_refuses_a_local_source_item(cli, parsed):
+    item_id, _ = parsed
+
+    payload = view_json(cli, item_id, "--download", exit_code=2)
+
+    assert payload["error"] == "not_a_url_source"
+    assert cli.transport.requests == []  # nothing fetched

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1091,3 +1091,24 @@ def test_crop_schema_tree_resolves_union_types_before_descending():
     html = (pathlib.Path(view.__file__).parent / "crop_template.html").read_text()
 
     assert 'const child = soleType(spec.type) === "array" ? spec.items : spec;' in html
+
+
+def test_url_parsed_item_note_explains_the_missing_preview_and_the_fix(cli):
+    """#169: a URL parse never hands the CLI the document bytes, so the
+    viewer cannot render page previews — the note must say why, what
+    still works, and the action that gets previews (not read as a broken
+    viewer)."""
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+
+    payload = view_json(cli, item_id)
+
+    assert payload["built"] is True
+    assert payload["pages_embedded"] == 0
+    assert "parsed from a URL" in payload["note"]
+    assert "ade parse -d" in payload["note"]  # the remediation
+    assert "unaffected" in payload["note"]  # what still works
+    # The artifact carries the same story: banner note + placeholders
+    # that point at it, and no lazy-load map that could spin forever.
+    data = embedded_data(cli, item_id)
+    assert "parsed from a URL" in data["note"]
+    assert data["page_chunks"] == []

--- a/tests/test_windows_hardening.py
+++ b/tests/test_windows_hardening.py
@@ -383,3 +383,176 @@ def test_lock_acquisition_retries_when_a_clear_razes_the_directory(
         assert (jobs.item_dir("cafe0123abcd4567") / ".ticket.lock").exists()
     assert entered
     assert calls["n"] == 3  # two lost races, then a clean acquisition
+
+
+# --- #171: process liveness probing must not assume POSIX errno types ------
+
+
+def test_alive_treats_a_bare_oserror_as_dead(monkeypatch):
+    """Windows raises bare OSError (WinError 87) for a dead pid where
+    POSIX raises ProcessLookupError; the probe must read both as "not
+    alive", never crash the scan."""
+    from ade_cli import historyjs
+
+    def winerror_kill(pid, sig):
+        raise OSError(22, "The parameter is incorrect")
+
+    monkeypatch.setattr(historyjs.os, "kill", winerror_kill)
+    assert historyjs._alive(999_999_999) is False
+
+
+def test_alive_still_reads_permission_denied_as_a_live_claim(monkeypatch):
+    from ade_cli import historyjs
+
+    def denied_kill(pid, sig):
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(historyjs.os, "kill", denied_kill)
+    assert historyjs._alive(1) is True
+
+
+def test_stale_builder_marker_never_crashes_view_or_history(
+    cli, document, monkeypatch
+):
+    """End-to-end shape of the QA crash: a .viewer.building marker naming
+    an exited pid, scanned by the history rewrite every view/history run
+    performs — with the platform raising the Windows-style bare OSError."""
+    from ade_cli import historyjs
+
+    item_id = parse_file(cli, document)
+    marker = cli.home / "jobs" / item_id / historyjs.BUILDING_MARKER
+    marker.write_text("999999999", encoding="utf-8")
+
+    def winerror_kill(pid, sig):
+        raise OSError(22, "The parameter is incorrect")
+
+    monkeypatch.setattr(historyjs.os, "kill", winerror_kill)
+
+    listed = cli.invoke("history", "list", "--json")
+    assert listed.exit_code == 0, listed.stdout
+
+    viewed = cli.invoke("view", item_id, "--no-open", "--no-sidebar-sync", "--json")
+    assert viewed.exit_code == 0, viewed.stdout
+    # The dead claim reads as not-building, so the next builder can reclaim.
+    status = historyjs.viewer_status(jobstore.JobStore(cli.home), item_id)
+    assert status != "building"
+
+
+# --- #168: piped-key detection works without select() ----------------------
+
+
+def test_poll_until_ready_reads_waiting_bytes_as_ready():
+    from ade_cli import filelock
+
+    assert filelock.poll_until_ready(lambda: 12, timeout=1.0) is True
+
+
+def test_poll_until_ready_reads_a_broken_pipe_as_ready():
+    """A writer that exited after closing its end: reading returns EOF
+    immediately, so the probe's None means ready, never a hang."""
+    from ade_cli import filelock
+
+    assert filelock.poll_until_ready(lambda: None, timeout=1.0) is True
+
+
+def test_poll_until_ready_times_out_on_a_silent_open_pipe():
+    from ade_cli import filelock
+
+    clock = {"now": 0.0}
+    sleeps: list[float] = []
+
+    def sleep(seconds):
+        sleeps.append(seconds)
+        clock["now"] += seconds
+
+    ready = filelock.poll_until_ready(
+        lambda: 0, timeout=0.25, monotonic=lambda: clock["now"], sleep=sleep
+    )
+
+    assert ready is False
+    assert sleeps  # sampled, not spun
+
+
+def test_piped_key_is_read_from_a_real_pipe(monkeypatch):
+    """The `echo $KEY | ade auth login` shape, against a real OS pipe with
+    a real fileno — the path the in-process runner's buffer never covers."""
+    from ade_cli import auth
+    from ade_cli.ports import Ports
+
+    read_end, write_end = os.pipe()
+    os.write(write_end, b"sk-piped-0123456789\n")
+    os.close(write_end)
+    stdin = os.fdopen(read_end, "r")
+    monkeypatch.setattr(auth.sys, "stdin", stdin)
+    try:
+        key = auth._piped_api_key(Ports(stdin_tty=False))
+    finally:
+        stdin.close()
+
+    assert key == "sk-piped-0123456789"
+
+
+def test_a_silent_open_pipe_yields_no_key_without_hanging(monkeypatch):
+    from ade_cli import auth
+    from ade_cli.ports import Ports
+
+    monkeypatch.setattr(auth, "_PIPED_KEY_TIMEOUT", 0.05)
+    read_end, write_end = os.pipe()  # writer stays open and silent
+    stdin = os.fdopen(read_end, "r")
+    monkeypatch.setattr(auth.sys, "stdin", stdin)
+    try:
+        key = auth._piped_api_key(Ports(stdin_tty=False))
+    finally:
+        stdin.close()
+        os.close(write_end)
+
+    assert key is None
+
+
+# --- #172: path errors carry the path as typed, not repr()-escaped ---------
+
+
+def test_windows_path_errors_carry_single_backslashes_in_json(cli):
+    """typer's path validation formats the offending path with repr(),
+    doubling every backslash; the --json payload must undo it so the
+    message carries the path as typed."""
+    result = cli.invoke("parse", "-d", "C:\\fake\\dir\\missing.pdf", "--json")
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "bad_parameter"
+    assert "C:\\fake\\dir\\missing.pdf" in payload["message"]
+    assert "\\\\" not in payload["message"]
+
+
+def test_id_only_path_errors_share_the_unescaped_message(cli):
+    result = cli.invoke("parse", "-d", "C:\\fake\\missing.pdf", "--id-only")
+
+    assert result.exit_code == 2
+    assert result.stdout.strip() == ""
+    assert "C:\\fake\\missing.pdf" in result.stderr
+    assert "\\\\" not in result.stderr
+
+
+def test_unc_style_prefixes_survive_the_unescape(cli):
+    """repr of a UNC path (\\\\server\\share) collapses back to exactly
+    the typed form — the replace must not eat the leading double slash."""
+    result = cli.invoke(
+        "parse", "-d", "\\\\server\\share\\missing.pdf", "--json"
+    )
+
+    assert result.exit_code == 2
+    assert "\\\\server\\share\\missing.pdf" in json.loads(result.stdout)["message"]
+
+
+def test_background_children_detach_with_platform_appropriate_kwargs():
+    """start_new_session is silently ignored on Windows — the detachment
+    must go through creationflags there (POSIX keeps the session split).
+    Asserted on the POSIX side here; the nt branch is a constant."""
+    from ade_cli import view
+
+    kwargs = view._detach_kwargs()
+    if os.name == "nt":  # pragma: no cover - exercised on Windows only
+        assert kwargs["creationflags"]
+    else:
+        assert kwargs == {"start_new_session": True}


### PR DESCRIPTION
Fixes the six v1.0.2 QA reports from the ADE - QA - Testing board, plus a broader sweep for the same failure classes.

## The six reported bugs

### 1. Pending message never names the job item id (closes #167)
`exit_pending`'s human string only surfaced the run id. Fixed via a shared `_item_label()` on the guarantee, applied to **every** human message that names a run — pending (both branches, the lease-takeover one included per the report's suggestion), failed, unexpected-status, missing-result, and unsupported-schema — so no residual gaps of the same shape remain.

### 2. `echo $KEY | ade auth login` never detected on Windows (closes #168)
Exactly the confirmed root cause: `select.select()` supports only sockets on Windows and raised WinError 10093 on piped stdin every time, silently swallowed. The probe now lives in `filelock.py` (the repo's platform-primitive quarantine module, charter widened) as `stdin_ready()`: select on POSIX, `PeekNamedPipe` on Windows — files always read as ready, silent-open pipes still time out inside the same 0.25s budget, and a broken pipe reads as EOF-ready. The poll decision table is a pure function, tested cross-platform; plus real-OS-pipe tests for the detected and not-detected cases.

### 3. Doc preview doesn't load after `parse --document-url` (closes #169)
**Not a Python-version issue** — it's by design: URL parses never hand the CLI the document bytes, so there is nothing local to raster. Per the ask, the fix is honest messaging with an action everywhere the gap shows: the viewer banner and per-page placeholders (which now point at the banner instead of saying "boxes approximate"), `ade view`'s `note:`, and `ade crop`'s `source_missing` error all say why, that markdown/elements/extractions are unaffected, and how to get previews (download the file and `ade parse -d <file>`). The missing-file note gained the same remediation shape.

### 4. `extract`'s `next:` hint points at the parse viewer (closes #170)
Hint now names the extract item's own id — the only viewer that renders the extraction (`_load_bundle` holds parse viewers to parse only by design). The stale pre-2026-07-21 comment is gone, and bring-your-own-markdown extractions get the hint too (they own a viewer since that change).

### 5. `ade view`/`ade history` crash with OSError [WinError 87] (closes #171)
Confirmed — and it's worse than reported: on Windows `os.kill(pid, sig)` calls **TerminateProcess** for any sig outside the CTRL events, signal 0 included, so probing a *live* builder killed it mid-build (silently), and probing a dead pid raised the bare OSError QA caught. `_alive` now probes via `OpenProcess`/`GetExitCodeProcess` on Windows (access-denied = live claim); POSIX keeps `kill(pid, 0)` with the except widened to bare OSError. End-to-end regression test: a stale `.viewer.building` marker + WinError-style `os.kill` never crashes `view`/`history`, and the dead claim reads as not-building.

### 6. Doubled backslashes in `--json` path errors (closes #172)
Took the report's option (b): the #155 reshaping layer now undoes typer's `repr()`-doubled backslashes for path-typed params — in both the `--json` payload and the `--id-only` stderr message — with UNC prefixes surviving exactly (`\\\\server\\share` → `\\server\share`). Our own `--schema` messages stop using `!r` on user paths (the same class in our code); a repo-wide `!r` sweep found no other path-valued uses. The rich human box keeps typer's rendering (upstreamable separately).

## Broader sweep (as requested)
- **Same class as #162**: the two remaining unretried `os.replace` calls on shared files — `shipping.py`'s telemetry-ledger rotate and `update.py`'s throttle stamp — now share `store.replace_with_retry`.
- **Same class as #171/#168 (POSIX assumptions)**: audited every `os.kill`/`select` use; `serve.py`'s SIGTERM kill is intentional termination with `except OSError` and is correct on Windows.
- **Found while auditing spawn paths**: `start_new_session=True` is *silently ignored* on Windows, so the "detached" sidebar builder and viewer server stayed attached to the parent console — Ctrl-C or closing the terminal killed them mid-build. They now detach for real there (`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`; stdio is already DEVNULL and stdout is UTF-8-safe since #161).

## Tests
682 total (+16 new): pending/failed human ids, poll decision table + real-pipe piped-key detection, URL-note remediation in view + crop, extract-hint ownership (parse-backed and markdown), `_alive` OSError widening + stale-marker end-to-end, backslash unescaping (`--json`, `--id-only`, UNC), platform detach kwargs. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)