### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ade-cli"
-version = "1.0.2"
+version = "1.0.3"
 description = "CLI for Agentic Document Extraction (ADE) — parse and extract documents with the v2 APIs, backed by a local store"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ade-cli"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bump `pyproject.toml` and `uv.lock` to 1.0.3 (2-line surgical diff), picking up #173 — the v1.0.2 QA sweep:

- Every run-naming human message also names the job item id (#167).
- `echo $KEY | ade auth login` works on Windows — PeekNamedPipe stdin probe (#168).
- URL parses: actionable preview messaging, plus **`parse --keep-copy`** and **`ade view <id> --download`** to attach the document bytes so previews/crops render (calm banner with hover explanation) (#169).
- `extract`'s `next:` hint names the extract item's own viewer (#170).
- Windows-safe process liveness probe — no more WinError 87 crashes, and no more `os.kill(pid, 0)` terminating live builders (#171).
- Windows path errors carry single backslashes in `--json`/`--id-only` (#172).
- `history list`: newest-first default with `--asc`, capped at the newest 100 with a leading notice, `--limit N` / `--all`.
- Sweep hardening: retried `os.replace` for the telemetry ledger and update stamp, genuinely detached background children on Windows, Win32 ctypes signature declarations, streamed download cap.
- Docs: `job_id`-on-disk = `run_id` equivalence stated in help/README/SKILL.

Note for release notes: `history list --json` now returns the newest 100 items, newest first, by default (`--all` restores the previous full ascending listing behavior via `--all --asc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)