### PR TITLE
fix: auto-download URL-sourced documents on view/crop with notice and progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ open it exits immediately, naming all three paths.
 |---|---|
 | `ade parse -d invoice.pdf` | ensure parsed; artifacts land in `~/.ade` |
 | `ade parse --document-url https://…/doc.pdf` | server fetches the URL |
-| `ade parse --document-url https://… --keep-copy` | also store the document bytes locally, so page previews and crops render |
+| `ade parse --document-url https://… --keep-copy` | also store the document bytes locally, while the (often pre-signed) URL still works |
 | `ade parse -d doc.pdf --tier standard --wait 0` | cheap lane, submit-and-return |
 | `ade parse -d doc.pdf --env eu` | run in the EU region (or `export ADE_ENV=eu`) |
 | `ade parse -d doc.pdf --include markdown --json` | carry the markdown in the payload |
@@ -203,12 +203,14 @@ On a terminal, `view` opens the viewer in your browser by default
 (`--no-open` suppresses it); `--json` runs and piped output never
 launch a browser — the artifact path is in the output either way.
 Without a JOB_ITEM_ID, `view` targets the latest viewable job item.
-URL-parsed items have no local document bytes, so page previews can't
-render until you fetch them: `ade view <id> --download` attaches a copy
-of the document to the job item (plain HTTP, no API credits — but note
-pre-signed URLs expire, so `parse --keep-copy` at parse time is the
-reliable way), after which previews and crops render from it with an
-"unverified against the parsed run" caveat.
+URL-parsed items have no local document bytes, so on first `view` or
+`crop` the CLI fetches a copy of the document into the job item
+automatically — announced on stderr with a progress line, plain HTTP,
+no API credits (`--no-download` skips the fetch; previews then stay
+empty). Note pre-signed URLs expire, so `parse --keep-copy` at parse
+time is the reliable way to secure the bytes. Previews and crops render
+from the attached copy with an "unverified against the parsed run"
+caveat.
 
 Every job item gets a **self-contained `view.html`**: page images with
 bounding-box overlays beside the parsed markdown (or extraction JSON),

--- a/SKILL.md
+++ b/SKILL.md
@@ -184,8 +184,10 @@ clearing a parse item cascades to the extractions referencing it.
 - **`--markdown` extractions have no page evidence** (there is no parse
   to join against) — evidence degrades to spans-only, and `view`
   renders the markdown pane alone.
-- **URL parses have no local bytes**, so `view`/`crop` cannot render
-  page imagery until you attach a copy: `parse --document-url …
-  --keep-copy` at parse time (reliable — pre-signed URLs expire), or
-  `ade view <id> --download` after the fact. Markdown, elements, and
-  extractions work either way.
+- **URL parses have no local bytes**, so page imagery renders from an
+  attached copy: `parse --document-url … --keep-copy` fetches it at
+  parse time (reliable — pre-signed URLs expire); otherwise the first
+  `view`/`crop` downloads it automatically (`--no-download` skips;
+  the payload records `downloaded`, and on a failed fetch `view`
+  degrades to an empty preview with `download_error` while `crop`
+  errors). Markdown, elements, and extractions work either way.

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -472,7 +472,7 @@
           "metavar": null,
           "required": false,
           "default": null,
-          "help": "--document-url only: also download the document into the job item (plain HTTP, no API credits) so page previews and crops render locally \u2014 fetched now, while the URL (often pre-signed) still works. Without it, URL parses have no local bytes and the viewer explains how to fetch them later (`ade view <id> --download`)."
+          "help": "--document-url only: also download the document into the job item (plain HTTP, no API credits) so page previews and crops render locally \u2014 fetched now, while the URL (often pre-signed) still works. Without it, the first `view`/`crop` fetches the copy instead, by which time a pre-signed URL may have expired."
         },
         {
           "flags": "--include",
@@ -999,11 +999,11 @@
           "help": "Pages to embed images for, 1-indexed, e.g. '1,3-5'."
         },
         {
-          "flags": "--download",
+          "flags": "--download, --no-download",
           "metavar": null,
           "required": false,
           "default": null,
-          "help": "URL-parsed items: fetch the document from its recorded URL into the job item and render page previews from that copy \u2014 the parse itself never gives the CLI the bytes (#169). Plain HTTP, no API credits; the copy is unverified against the parsed run. Also works on an extract item id (fetches into its referenced parse item)."
+          "help": "URL-parsed items: fetch the document from its recorded URL into the job item and render page previews from that copy \u2014 the parse itself never gives the CLI the bytes (#169). This happens automatically when no copy is attached yet (a notice and progress line land on stderr); --no-download skips the fetch and previews stay empty. Explicit --download makes a failed fetch an error instead of a warning. Plain HTTP, no API credits; the copy is unverified against the parsed run. Also works on an extract item id (fetches into its referenced parse item)."
         },
         {
           "flags": "--no-sidebar-sync",
@@ -1061,7 +1061,11 @@
           },
           {
             "key": "downloaded",
-            "what": "with --download: true when this run fetched the URL document into the job item (false: already attached)"
+            "what": "URL items: true when this run fetched the document into the job item (automatic on first view; false: already attached, or the automatic fetch failed \u2014 see download_error)"
+          },
+          {
+            "key": "download_error",
+            "what": "why the automatic fetch failed, when it did (the viewer still builds, previews empty; else absent)"
           },
           {
             "key": "deep_link",
@@ -1139,6 +1143,13 @@
           "required": false,
           "default": null,
           "help": "Open the crop (or the directory holding them)."
+        },
+        {
+          "flags": "--download, --no-download",
+          "metavar": null,
+          "required": false,
+          "default": null,
+          "help": "URL-parsed items: fetch the document from its recorded URL into the job item and crop from that copy \u2014 the parse itself never gives the CLI the bytes (#169). This happens automatically when no copy is attached yet (a notice and progress line land on stderr); --no-download skips the fetch, and the crop then fails honestly (a crop has no empty-imagery fallback)."
         }
       ],
       "supports_json": true,
@@ -1331,7 +1342,7 @@
       },
       {
         "path": "  document.<ext>",
-        "what": "URL parses: the attached document copy (`parse --keep-copy` / `view --download`) page previews and crops render from \u2014 unverified against the parsed run"
+        "what": "URL parses: the attached document copy (`parse --keep-copy`, or fetched automatically on first `view`/`crop`) page previews and crops render from \u2014 unverified against the parsed run"
       },
       {
         "path": "  view.html / crops/",

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -1061,7 +1061,7 @@
           },
           {
             "key": "downloaded",
-            "what": "URL items: true when this run fetched the document into the job item (automatic on first view; false: already attached, or the automatic fetch failed \u2014 see download_error)"
+            "what": "URL items: true when this run fetched the document into the job item (automatic on first view). false when the automatic fetch failed (see download_error) or explicit --download found the copy already attached; absent when nothing needed fetching"
           },
           {
             "key": "download_error",
@@ -1175,6 +1175,10 @@
           {
             "key": "crops",
             "what": "one record per PNG (element_id, type, page, box, dpi, path, width, height)"
+          },
+          {
+            "key": "downloaded",
+            "what": "URL items: true when this run fetched the document into the parse item before cropping (absent when nothing needed fetching)"
           }
         ],
         "note": "One shape whatever matched: a single --element-id is count 1 with one crops[] record; a filter (--type/--page/--all) matching nothing is count 0 with crops []."

--- a/src/ade_cli/attach.py
+++ b/src/ade_cli/attach.py
@@ -2,19 +2,22 @@
 
 ``parse --document-url`` never hands the CLI the document bytes — the
 server fetches the URL — so page previews and crops have nothing local
-to render from. An *attached copy* closes that gap on explicit consent:
-``parse --keep-copy`` downloads the document at parse time (while the
-URL — often pre-signed — still works), and ``view --download`` fetches
-it after the fact. The copy lives inside the job item
-(``jobs/<id>/document.<ext>``) and is recorded on meta.json as auxiliary
-metadata: the recorded ``source`` stays the URL (provenance truth) and
-the item id never moves. The raster layer falls back to the copy via
-``renderable_source``.
+to render from. An *attached copy* closes that gap: ``parse
+--keep-copy`` downloads the document at parse time (while the URL —
+often pre-signed — still works), and ``view`` / ``crop`` fetch it on
+first use — automatically when the item is URL-sourced and no copy is
+attached yet, announced by a stderr notice + progress line
+(``download_with_notice``), suppressible with ``--no-download``. The
+copy lives inside the job item (``jobs/<id>/document.<ext>``) and is
+recorded on meta.json as auxiliary metadata: the recorded ``source``
+stays the URL (provenance truth) and the item id never moves. The
+raster layer falls back to the copy via ``renderable_source``.
 
-The CLI still never fetches a URL without one of these explicit flags —
-and because it never saw the original bytes, an attached copy is not
-verifiable against the parsed generation: renders from it carry the
-``caveat`` note rather than posing as ground truth.
+A URL fetch is therefore never *silent* — it is either asked for at
+parse time or said out loud before it starts — and because the CLI
+never saw the original bytes, an attached copy is not verifiable
+against the parsed generation: renders from it carry the ``caveat``
+note rather than posing as ground truth.
 """
 
 from __future__ import annotations
@@ -25,6 +28,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
+import typer
 
 from .store import JobStore, replace_with_retry
 
@@ -118,13 +122,19 @@ def download(
     *,
     transport: httpx.BaseTransport,
     now: float,
+    progress=None,
 ) -> tuple[str, int]:
     """Fetch the item's URL source and attach the copy; returns
     ``(filename, bytes)``. Raises AttachError with the remediation —
     pre-signed URLs expire, so a late fetch failing is the expected
-    failure mode, not a surprise."""
+    failure mode, not a surprise. ``progress`` (a ``guarantee.Progress``)
+    reports received/total per chunk; a body without Content-Length
+    still shows the moving label, just without a percentage."""
     url = meta.get("source") or ""
     name = copy_name(url)
+    label = f"downloading {name}"
+    if progress is not None:
+        progress.update(label=label)
     target = jobs.item_dir(item_id) / name
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_name(f".{name}.tmp-{os.getpid()}")
@@ -156,6 +166,7 @@ def download(
                         f"{MAX_COPY_BYTES}-byte attach cap; parse the local "
                         "file instead (ade parse -d <file>).",
                     )
+                total = int(declared) if declared.isdigit() else 0
                 with tmp.open("wb") as sink:
                     for chunk in response.iter_bytes():
                         received += len(chunk)
@@ -168,6 +179,10 @@ def download(
                             )
                         digest.update(chunk)
                         sink.write(chunk)
+                        if progress is not None and total:
+                            progress.update(
+                                label=label, fraction=received / total
+                            )
     except httpx.HTTPError as error:
         tmp.unlink(missing_ok=True)
         raise AttachError(
@@ -198,3 +213,44 @@ def download(
         )
         jobs.write_json(item_id, "meta.json", current)
     return name, received
+
+
+def download_with_notice(
+    jobs: JobStore,
+    item_id: str,
+    meta: dict,
+    *,
+    ports,
+    as_json: bool,
+) -> tuple[str, int]:
+    """``download`` with the say-it-out-loud surface around it: a stderr
+    notice naming why the network is about to be touched and how to
+    suppress it, then a progress line while the body streams. stderr
+    only, fully silent under ``--json`` (the payload carries the
+    receipt); raises AttachError exactly like ``download``."""
+    # Lazy import mirrors update.py's: guarantee.py imports update, which
+    # would make a top-level import here a needlessly heavy chain.
+    from .guarantee import Progress
+
+    if not as_json:
+        typer.echo(
+            f"note: job item {item_id} was parsed from a URL and no local "
+            "copy is attached — downloading it so page imagery can render "
+            "(skip with --no-download)",
+            err=True,
+        )
+    progress = Progress(
+        ports.clock,
+        "off" if as_json else ("tty" if ports.stderr_is_tty() else "plain"),
+    )
+    try:
+        return download(
+            jobs,
+            item_id,
+            meta,
+            transport=ports.transport,
+            now=ports.clock.now(),
+            progress=progress,
+        )
+    finally:
+        progress.close()

--- a/src/ade_cli/crop.py
+++ b/src/ade_cli/crop.py
@@ -161,6 +161,7 @@ def find_element_or_exit(
 
 
 def crop(
+    ctx: typer.Context,
     job_id_token: str | None = typer.Argument(
         None, metavar="[JOB_ITEM_ID]", help="Job item id or unambiguous prefix."
     ),
@@ -193,6 +194,16 @@ def crop(
     dpi: int = typer.Option(DEFAULT_CROP_DPI, "--dpi", min=1, help="Render dpi."),
     open_image: bool = typer.Option(
         False, "--open", help="Open the crop (or the directory holding them)."
+    ),
+    download: bool | None = typer.Option(
+        None, "--download/--no-download",
+        help="URL-parsed items: fetch the document from its recorded URL "
+        "into the job item and crop from that copy — the parse itself "
+        "never gives the CLI the bytes (#169). This happens "
+        "automatically when no copy is attached yet (a notice and "
+        "progress line land on stderr); --no-download skips the fetch, "
+        "and the crop then fails honestly (a crop has no empty-imagery "
+        "fallback).",
     ),
     as_json: bool = JSON_FLAG,
 ) -> None:
@@ -234,11 +245,61 @@ def crop(
     selected = elements.select(
         records, element_type=element_type, page=page, element_ids=element_ids
     )
+    parse_meta = jobs.read_json(parse_item_id, "meta.json")
+    if download and not attach.is_url_source(parse_meta):
+        message = (
+            f"Job item {item_id} has no URL source to download: "
+            "--download applies to items parsed from --document-url "
+            "(local parses crop from their file directly)."
+        )
+        exit_with(
+            {
+                "error": "not_a_url_source",
+                "job_item_id": item_id,
+                "message": message,
+            },
+            message,
+            as_json=as_json,
+            code=EXIT_USAGE,
+        )
+    # A URL parse without an attached copy has nothing local to crop
+    # from, so the copy fetches now by default — announced on stderr,
+    # suppressible with --no-download (#169 follow-up, mirroring `view`).
+    # Unlike view there is no degraded render to fall back to (a crop is
+    # never served from missing imagery), so a failed fetch is the
+    # command's failure, exactly as the no-copy state already was.
+    downloaded = None
+    if (
+        download is not False
+        and selected
+        and attach.is_url_source(parse_meta)
+        and attach.attached_file(jobs, parse_item_id, parse_meta) is None
+    ):
+        try:
+            attach.download_with_notice(
+                jobs,
+                parse_item_id,
+                parse_meta or {},
+                ports=ctx.obj,
+                as_json=as_json,
+            )
+        except attach.AttachError as error:
+            exit_with(
+                {
+                    "error": error.kind,
+                    "job_item_id": parse_item_id,
+                    "message": error.message,
+                },
+                error.message,
+                as_json=as_json,
+                code=EXIT_FAILED,
+            )
+        downloaded = True
+        parse_meta = jobs.read_json(parse_item_id, "meta.json")
     # One drift check per invocation, not per element: the batch renders
     # from a single recorded source, and hashing it once is the whole cost.
     # URL items have no drift check (no recorded content hash); a render
     # from their attached copy carries the unverified-bytes caveat instead.
-    parse_meta = jobs.read_json(parse_item_id, "meta.json")
     drift = source_drift_note(parse_meta) or attach.caveat(
         jobs, parse_item_id, parse_meta
     )
@@ -271,8 +332,9 @@ def crop(
             message = error.message
             if "parsed from a URL" in message:
                 message += (
-                    f" Fetch it with `ade view {parse_item_id} --download`, "
-                    "then re-run this crop."
+                    " Re-run without --no-download to fetch the document, "
+                    f"or fetch it with `ade view {parse_item_id} "
+                    "--download` first."
                 )
                 tail = ""
             else:
@@ -312,6 +374,7 @@ def crop(
         "count": len(crops),
         "directory": str(landed),
         "crops": crops,
+        **({"downloaded": downloaded} if downloaded is not None else {}),
         **({"warning": drift} if drift else {}),
     }
     if not batch:

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -237,6 +237,9 @@ RESULTS: dict[str, dict] = {
             ("directory", "where they landed"),
             ("crops", "one record per PNG (element_id, type, "
              "page, box, dpi, path, width, height)"),
+            ("downloaded", "URL items: true when this run fetched the "
+             "document into the parse item before cropping (absent when "
+             "nothing needed fetching)"),
         ],
         "note": "One shape whatever matched: a single --element-id is "
         "count 1 with one crops[] record; a filter (--type/--page/--all) "
@@ -253,9 +256,10 @@ RESULTS: dict[str, dict] = {
             ("pages_embedded", "pages inlined; the rest load from sidecars"),
             ("note", "why the render weakened, when it did (else null)"),
             ("downloaded", "URL items: true when this run fetched the "
-             "document into the job item (automatic on first view; false: "
-             "already attached, or the automatic fetch failed — see "
-             "download_error)"),
+             "document into the job item (automatic on first view). false "
+             "when the automatic fetch failed (see download_error) or "
+             "explicit --download found the copy already attached; absent "
+             "when nothing needed fetching"),
             ("download_error", "why the automatic fetch failed, when it "
              "did (the viewer still builds, previews empty; else absent)"),
             ("deep_link", "view.html#element=... when --element-id was given"),

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -252,8 +252,12 @@ RESULTS: dict[str, dict] = {
             ("built", "true when this run rebuilt the artifact"),
             ("pages_embedded", "pages inlined; the rest load from sidecars"),
             ("note", "why the render weakened, when it did (else null)"),
-            ("downloaded", "with --download: true when this run fetched "
-             "the URL document into the job item (false: already attached)"),
+            ("downloaded", "URL items: true when this run fetched the "
+             "document into the job item (automatic on first view; false: "
+             "already attached, or the automatic fetch failed — see "
+             "download_error)"),
+            ("download_error", "why the automatic fetch failed, when it "
+             "did (the viewer still builds, previews empty; else absent)"),
             ("deep_link", "view.html#element=... when --element-id was given"),
             ("history_items", "items in the rebuilt sidebar read model"),
             ("sidebar_sync", "true when sibling viewers build in the background"),
@@ -490,8 +494,9 @@ STORE_LAYOUT = [
     {
         "path": "  document.<ext>",
         "what": "URL parses: the attached document copy (`parse "
-        "--keep-copy` / `view --download`) page previews and crops render "
-        "from — unverified against the parsed run",
+        "--keep-copy`, or fetched automatically on first `view`/`crop`) "
+        "page previews and crops render from — unverified against the "
+        "parsed run",
     },
     {
         "path": "  view.html / crops/",

--- a/src/ade_cli/parse.py
+++ b/src/ade_cli/parse.py
@@ -157,9 +157,9 @@ def parse(
         help="--document-url only: also download the document into the "
         "job item (plain HTTP, no API credits) so page previews and "
         "crops render locally — fetched now, while the URL (often "
-        "pre-signed) still works. Without it, URL parses have no local "
-        "bytes and the viewer explains how to fetch them later "
-        "(`ade view <id> --download`).",
+        "pre-signed) still works. Without it, the first `view`/`crop` "
+        "fetches the copy instead, by which time a pre-signed URL may "
+        "have expired.",
     ),
     include: list[Include] = typer.Option(
         [],
@@ -324,8 +324,8 @@ def parse(
                 # a warning with the later remediation, never a failure.
                 copy_line = (
                     f"\n  copy:    keep-copy failed — {copy_info['error']} "
-                    f"(the parse succeeded; `ade view {ref} --download` "
-                    "can fetch the copy later)"
+                    f"(the parse succeeded; `ade view {ref}` retries the "
+                    "fetch automatically)"
                 )
             else:
                 copy_line = (

--- a/src/ade_cli/view.py
+++ b/src/ade_cli/view.py
@@ -183,7 +183,7 @@ def _referencing_extractions(
 def _imagery_source(store: JobStore, bundle: dict) -> str | None:
     """What this bundle's page imagery renders from: the parse item's
     recorded source, or its attached copy for URL parses (#169 —
-    `parse --keep-copy` / `view --download`)."""
+    `parse --keep-copy`, or fetched on first `view`/`crop`)."""
     owner = bundle.get("parse_item_id") or bundle["record"]["job_item_id"]
     return attach.renderable_source(store, owner, bundle["parse_meta"])
 
@@ -642,13 +642,15 @@ def _build(
     banner_note = note
     # A URL item's missing preview gets the id-bearing action (#169): the
     # cause comes from the raster layer; the command that fixes it needs
-    # the item id, which only this layer holds.
+    # the item id, which only this layer holds. The fetch is automatic
+    # now, so this note survives only a failed or suppressed download —
+    # the action is a retry, not a flag to discover.
     if note and note.startswith("source unavailable: parsed from a URL"):
         owner_id = bundle.get("parse_item_id") or item_id
         action = (
-            f" Fetch them with `ade view {items.short_id(store, owner_id)} "
-            "--download`, or keep a copy at parse time with "
-            "`parse --keep-copy`."
+            f" Re-run `ade view {items.short_id(store, owner_id)} "
+            "--download` to fetch them, or keep a copy at parse time "
+            "with `parse --keep-copy`."
         )
         note += action
         banner_note = note
@@ -985,14 +987,18 @@ def view(
     pages: str | None = typer.Option(
         None, "--pages", help="Pages to embed images for, 1-indexed, e.g. '1,3-5'."
     ),
-    download: bool = typer.Option(
-        False, "--download",
+    download: bool | None = typer.Option(
+        None, "--download/--no-download",
         help="URL-parsed items: fetch the document from its recorded URL "
         "into the job item and render page previews from that copy — "
-        "the parse itself never gives the CLI the bytes (#169). Plain "
-        "HTTP, no API credits; the copy is unverified against the "
-        "parsed run. Also works on an extract item id (fetches into "
-        "its referenced parse item).",
+        "the parse itself never gives the CLI the bytes (#169). This "
+        "happens automatically when no copy is attached yet (a notice "
+        "and progress line land on stderr); --no-download skips the "
+        "fetch and previews stay empty. Explicit --download makes a "
+        "failed fetch an error instead of a warning. Plain HTTP, no API "
+        "credits; the copy is unverified against the parsed run. Also "
+        "works on an extract item id (fetches into its referenced parse "
+        "item).",
     ),
     no_sidebar_sync: bool = typer.Option(
         False, "--no-sidebar-sync",
@@ -1112,12 +1118,19 @@ def view(
 
     record = items.item_record(store, item_id)
 
-    # --download (#169): attach the URL document's bytes to the imagery
-    # owner (the item itself, or a referencing extract's parse item)
-    # BEFORE the bundle loads, so this same run renders from the copy.
+    # Attaching the URL document's bytes happens on the imagery owner
+    # (the item itself, or a referencing extract's parse item) BEFORE the
+    # bundle loads, so this same run renders from the copy. Default is
+    # AUTO (#169 follow-up): a URL-sourced item with no attached copy
+    # fetches now — announced on stderr, never silently — because an
+    # empty preview surprised users more than an implicit fetch;
+    # --no-download suppresses. Explicit --download keeps the strict
+    # contract: wrong-kind items and failed fetches are errors, and the
+    # already-attached case still gets its receipt line.
     download_line = ""
     downloaded: bool | None = None
-    if download:
+    download_error: str | None = None
+    if download is not False:
         if record["kind"] == "parse":
             owner_id = item_id
         else:
@@ -1128,7 +1141,8 @@ def view(
         owner_meta = (
             store.read_json(owner_id, "meta.json") if owner_id else None
         )
-        if not owner_id or not attach.is_url_source(owner_meta):
+        url_source = owner_id is not None and attach.is_url_source(owner_meta)
+        if download and not url_source:
             message = (
                 f"Job item {item_id} has no URL source to download: "
                 "--download applies to items parsed from --document-url "
@@ -1144,38 +1158,54 @@ def view(
                 as_json=as_json,
                 code=EXIT_USAGE,
             )
-        already = attach.attached_file(store, owner_id, owner_meta)
-        if already is not None:
+        already = (
+            attach.attached_file(store, owner_id, owner_meta)
+            if url_source
+            else None
+        )
+        if download and already is not None:
             downloaded = False
             download_line = (
                 f"\n  download: copy already attached ({already.name}); "
                 "previews render from it"
             )
-        else:
+        elif url_source and already is None:
             try:
-                name, size = attach.download(
+                name, size = attach.download_with_notice(
                     store,
                     owner_id,
                     owner_meta or {},
-                    transport=ports.transport,
-                    now=ports.clock.now(),
+                    ports=ports,
+                    as_json=as_json,
                 )
             except attach.AttachError as error:
-                exit_with(
-                    {
-                        "error": error.kind,
-                        "job_item_id": owner_id,
-                        "message": error.message,
-                    },
-                    error.message,
-                    as_json=as_json,
-                    code=EXIT_FAILED,
+                if download:
+                    exit_with(
+                        {
+                            "error": error.kind,
+                            "job_item_id": owner_id,
+                            "message": error.message,
+                        },
+                        error.message,
+                        as_json=as_json,
+                        code=EXIT_FAILED,
+                    )
+                # Auto mode degrades instead of failing: yesterday's
+                # working `ade view` must not start exiting non-zero the
+                # day the pre-signed URL expires — the viewer still
+                # builds, with the honest empty-preview note.
+                downloaded = False
+                download_error = error.message
+                download_line = (
+                    "\n  download: failed — page previews stay empty "
+                    f"({error.message})"
                 )
-            downloaded = True
-            download_line = (
-                f"\n  download: fetched {name} ({size:,} bytes) into job "
-                f"item {owner_id}"
-            )
+            else:
+                downloaded = True
+                download_line = (
+                    f"\n  download: fetched {name} ({size:,} bytes) into "
+                    f"job item {owner_id}"
+                )
 
     try:
         bundle = _load_bundle(store, item_id)
@@ -1223,8 +1253,8 @@ def view(
             if "parsed from a URL" in message:
                 owner_id = bundle.get("parse_item_id") or item_id
                 message += (
-                    f" Fetch it with `ade view {owner_id} --download`, "
-                    "then re-run."
+                    f" Re-run `ade view {owner_id} --download` to fetch "
+                    "it, then re-run this crop."
                 )
                 tail = ""
             else:
@@ -1381,6 +1411,8 @@ def view(
     }
     if downloaded is not None:
         payload["downloaded"] = downloaded
+    if download_error is not None:
+        payload["download_error"] = download_error
     hint = f"ade view {items.short_id(store, item_id)} --open" + (
         f" --element-id {element_id}" if element_id else ""
     )

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -598,9 +598,8 @@ def test_single_crop_output_path_creates_missing_parents(cli, parsed, tmp_path):
     assert payload["directory"] == str(out.parent)
 
 
-def test_crop_of_a_url_parsed_item_names_the_remediation(cli):
-    """#169's crop face: a URL parse has no local bytes to crop from — the
-    error must say why and how to get crops, not claim a file vanished."""
+def url_parsed(cli):
+    """Seed a URL-sourced parse item through the seam; returns its id."""
     cli.transport.respond(202, {"job_id": "job-0001"})
     cli.transport.respond(200, completed_job(rich_parse_response()))
     parsed = cli.invoke(
@@ -608,10 +607,71 @@ def test_crop_of_a_url_parsed_item_names_the_remediation(cli):
         "--json", env=AUTH_ENV,
     )
     assert parsed.exit_code == 0, parsed.stdout
-    item_id = json.loads(parsed.stdout)["job_item_id"]
+    return json.loads(parsed.stdout)["job_item_id"]
 
-    payload = crop_json(cli, item_id, "--element-id", "text-0", exit_code=1)
+
+def test_crop_of_a_url_parsed_item_names_the_remediation(cli):
+    """#169's crop face: a URL parse with the fetch suppressed has no
+    local bytes to crop from — the error must say why and how to get
+    crops, not claim a file vanished."""
+    item_id = url_parsed(cli)
+
+    payload = crop_json(
+        cli, item_id, "--element-id", "text-0", "--no-download", exit_code=1
+    )
 
     assert payload["error"] == "source_missing"
     assert "parsed from a URL" in payload["message"]
+    assert "--no-download" in payload["message"]  # the suppressed fetch
     assert "ade parse -d" in payload["message"]
+
+
+def test_crop_auto_downloads_the_url_document(cli, pdf):
+    """A plain `ade crop` on a URL-sourced item fetches the copy by
+    default (mirroring `view`) and crops from it in the same run, with
+    the unverified-bytes caveat as its warning."""
+    import httpx
+
+    item_id = url_parsed(cli)
+    body = pdf.read_bytes()
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=body))
+
+    payload = crop_json(cli, item_id, "--element-id", "text-0")
+
+    assert payload["status"] == "cropped"
+    assert payload["downloaded"] is True
+    assert "downloaded copy" in payload["warning"]
+    assert str(cli.transport.requests[-1].url) == "https://example.com/doc.pdf"
+    assert (cli.home / "jobs" / item_id / "document.pdf").read_bytes() == body
+
+    # The copy attached: the next crop has nothing to fetch.
+    seen = len(cli.transport.requests)
+    again = crop_json(cli, item_id, "--element-id", "text-0")
+    assert len(cli.transport.requests) == seen
+    assert "downloaded" not in again
+
+
+def test_crop_auto_download_failure_is_the_crops_failure(cli):
+    """Unlike `view` there is no degraded render to fall back to — an
+    expired URL fails the crop with the download error, which is exactly
+    what the no-copy state already meant."""
+    import httpx
+
+    item_id = url_parsed(cli)
+    cli.transport.respond_with(lambda req: httpx.Response(403, content=b"denied"))
+
+    payload = crop_json(cli, item_id, "--element-id", "text-0", exit_code=1)
+
+    assert payload["error"] == "download_failed"
+    assert "expire" in payload["message"]
+    assert not (cli.home / "jobs" / item_id / "document.pdf").exists()
+
+
+def test_crop_download_refuses_a_local_source_item(cli, parsed):
+    item_id, _ = parsed
+
+    payload = crop_json(
+        cli, item_id, "--element-id", "text-0", "--download", exit_code=2
+    )
+
+    assert payload["error"] == "not_a_url_source"

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -42,7 +42,7 @@ def test_serve_reuses_a_running_server(cli, parsed_url_item, monkeypatch):
         "ade_cli.view._spawn_server",
         lambda port: pytest.fail("a live server must be reused, not respawned"),
     )
-    payload = view_json(cli, item_id, "--serve")
+    payload = view_json(cli, item_id, "--serve", "--no-download")
     assert payload["url"] == f"http://127.0.0.1:8642/jobs/{item_id}/view.html"
     assert payload["serve_error"] is None
     probe = cli.transport.requests[-1]
@@ -64,7 +64,7 @@ def test_serve_spawns_the_daemon_and_waits_for_health(
         cli.transport.respond(200, _health_body(cli))
 
     monkeypatch.setattr("ade_cli.view._spawn_server", fake_spawn)
-    payload = view_json(cli, item_id, "--serve")
+    payload = view_json(cli, item_id, "--serve", "--no-download")
     assert spawned == [serve.DEFAULT_PORT]
     assert payload["url"] == f"http://127.0.0.1:8644/jobs/{item_id}/view.html"
     assert payload["deep_link"] is None
@@ -84,7 +84,7 @@ def test_serve_ignores_a_server_over_another_store(
         cli.transport.respond(200, _health_body(cli))
 
     monkeypatch.setattr("ade_cli.view._spawn_server", fake_spawn)
-    payload = view_json(cli, item_id, "--serve")
+    payload = view_json(cli, item_id, "--serve", "--no-download")
     assert payload["url"] == f"http://127.0.0.1:8645/jobs/{item_id}/view.html"
 
 
@@ -95,7 +95,8 @@ def test_serve_failure_degrades_to_file(cli, parsed_url_item, monkeypatch):
     monkeypatch.setattr("ade_cli.view._spawn_server", lambda port: None)
     opened = []
     result = cli.invoke(
-        "view", item_id, "--serve", "--open", "--no-sidebar-sync", "--json",
+        "view", item_id, "--serve", "--open", "--no-sidebar-sync", "--no-download",
+        "--json",
         browser=lambda url: opened.append(url) or True,
     )
     assert result.exit_code == 0, result.stdout
@@ -116,7 +117,7 @@ def test_serve_degrades_when_the_spawn_itself_fails(
         raise OSError("posix_spawn failed")
 
     monkeypatch.setattr("ade_cli.view._spawn_server", broken_spawn)
-    payload = view_json(cli, item_id, "--serve")
+    payload = view_json(cli, item_id, "--serve", "--no-download")
     assert payload["url"] is None
     assert "could not start the viewer server" in payload["serve_error"]
     assert payload["path"].endswith("view.html")
@@ -132,6 +133,7 @@ def test_serve_url_is_the_browser_target_with_deep_link(
     opened = []
     result = cli.invoke(
         "view", item_id, "--serve", "--open", "--element-id", "text-0",
+        "--no-download",
         "--no-sidebar-sync", "--json",
         browser=lambda url: opened.append(url) or True,
     )
@@ -147,7 +149,7 @@ def test_daemon_serves_artifacts_health_and_refuses_listings(cli, parsed_url_ite
     """The real handler on a real loopback socket: health names the store,
     artifacts stream, directory listings are refused (ADR-0005)."""
     item_id = parsed_url_item
-    view_json(cli, item_id)  # build the artifact the server will serve
+    view_json(cli, item_id, "--no-download")  # build what the server serves
     server = serve._bind(cli.home, 0)  # candidate 0 = OS-assigned, race-free
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -608,7 +608,7 @@ def test_view_never_reuses_an_unrenderable_build(cli, tmp_path):
 def test_view_degrades_for_url_documents(cli):
     item_id = seed_parse_item(cli, url="https://example.com/invoice.pdf")
 
-    payload = view_json(cli, item_id)
+    payload = view_json(cli, item_id, "--no-download")
 
     assert payload["built"] is True
     assert "URL" in payload["note"]
@@ -784,7 +784,7 @@ def test_history_js_neutralizes_script_closing_sequences(cli):
     # history.js injection posture).
     item_id = seed_parse_item(cli, url="https://x.test/</script><img src=x>")
 
-    view_json(cli, item_id)
+    view_json(cli, item_id, "--no-download")
 
     raw = (cli.home / "history.js").read_text(encoding="utf-8")
     assert "</script" not in raw
@@ -1094,21 +1094,22 @@ def test_crop_schema_tree_resolves_union_types_before_descending():
 
 
 def test_url_parsed_item_note_explains_the_missing_preview_and_the_fix(cli):
-    """#169: a URL parse never hands the CLI the document bytes, so the
-    viewer cannot render page previews — the note must say why, what
-    still works, and the action that gets previews (not read as a broken
-    viewer)."""
+    """#169: a URL parse never hands the CLI the document bytes, so a
+    viewer built without the copy (here: fetch suppressed) cannot render
+    page previews — the note must say why, what still works, and the
+    action that gets previews (not read as a broken viewer)."""
     item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
 
-    payload = view_json(cli, item_id)
+    payload = view_json(cli, item_id, "--no-download")
 
     assert payload["built"] is True
     assert payload["pages_embedded"] == 0
     assert "parsed from a URL" in payload["note"]
-    assert "--download" in payload["note"]  # the id-bearing action
+    assert "--download" in payload["note"]  # the id-bearing retry action
     assert item_id[:8] in payload["note"]
     assert "--keep-copy" in payload["note"]  # the parse-time alternative
     assert "unaffected" in payload["note"]  # what still works
+    assert cli.transport.requests == []  # --no-download means no fetch
     # The artifact carries the same story: banner note + placeholders
     # that point at it, and no lazy-load map that could spin forever.
     data = embedded_data(cli, item_id)
@@ -1181,6 +1182,74 @@ def test_view_download_is_idempotent(cli):
     assert payload["built"] is False  # the attach didn't move the fingerprint
     # The caveat lives in the already-built artifact's banner.
     assert "downloaded copy" in artifact(cli, item_id)
+
+
+def test_view_auto_downloads_a_url_item_without_a_copy(cli):
+    """A plain `ade view` on a URL-sourced item fetches the copy by
+    default — nobody should have to know a flag to see page previews;
+    the receipt records the fetch exactly like explicit --download."""
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    pdf = _pdf_bytes()
+    cli.transport.respond_with(lambda req: httpx.Response(200, content=pdf))
+
+    payload = view_json(cli, item_id)
+
+    assert payload["downloaded"] is True
+    assert payload["pages_embedded"] == 2
+    assert "downloaded copy" in payload["note"]
+    assert (cli.home / "jobs" / item_id / "document.pdf").read_bytes() == pdf
+
+    # Once attached, later views have nothing to fetch and no receipt.
+    seen = len(cli.transport.requests)
+    again = view_json(cli, item_id)
+    assert len(cli.transport.requests) == seen
+    assert "downloaded" not in again
+
+
+def test_view_auto_download_announces_itself_on_stderr(cli):
+    """The fetch is never silent (the whole point of the notice): a
+    human run says why the network is being touched and how to skip it,
+    and shows the download's progress; --json stays byte-stable and
+    quiet."""
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    pdf = _pdf_bytes()
+    cli.transport.respond_with(
+        lambda req: httpx.Response(
+            200, content=pdf, headers={"content-length": str(len(pdf))}
+        )
+    )
+
+    result = cli.invoke("view", item_id, "--no-sidebar-sync", "--no-open")
+
+    assert result.exit_code == 0, result.stdout
+    assert "parsed from a URL" in result.stderr
+    assert "--no-download" in result.stderr  # the opt-out, said up front
+    assert "downloading document.pdf" in result.stderr  # the progress line
+    assert "downloading" not in result.stdout  # payload stream untouched
+
+
+def test_view_auto_download_failure_degrades_to_the_empty_preview(cli):
+    """Auto mode never turns yesterday's working `ade view` into a
+    failure: an expired URL records the error and the viewer still
+    builds with the honest empty-preview note — only explicit
+    --download makes the fetch load-bearing."""
+    import httpx
+
+    item_id = seed_parse_item(cli, url="https://example.com/doc.pdf")
+    cli.transport.respond_with(lambda req: httpx.Response(403, content=b"denied"))
+
+    payload = view_json(cli, item_id)
+
+    assert payload["downloaded"] is False
+    assert "expire" in payload["download_error"]
+    assert payload["built"] is True
+    assert payload["pages_embedded"] == 0
+    assert "parsed from a URL" in payload["note"]
+    assert "--download" in payload["note"]  # the retry action
 
 
 def test_view_download_reports_an_expired_url(cli):


### PR DESCRIPTION
## Why

QA follow-up on the v1.0.2 "[STG-PROD][ADE][ADE-CLI] doc preview doesn't load after parsing with document URL" ticket: the `--download` flag added in #169's follow-up fixed the preview, but only opt-in — a plain `ade view <id>` on a URL-sourced parse still reported `pages_embedded: 0`, and a user who didn't know the flag saw an empty preview. Decision: the download becomes the default, said out loud rather than silent.

## What changes

- **`ade view` auto-fetches**: a URL-sourced item with no attached copy downloads on first view — a stderr notice explains why and names the opt-out, and the body streams behind the shared progress line (percent + elapsed rewriting in place on a tty, one line per 10% piped, silent under `--json`):

  ```
  note: job item 01fd4532c57f9b28 was parsed from a URL and no local copy is attached — downloading it so page imagery can render (skip with --no-download)
  downloading document.pdf 45% · 1s
  Viewer for job item 01fd4532c57f9b28 (parse) -> ~/.ade/jobs/…/view.html (built)
    download: fetched document.pdf (662 bytes) into job item 01fd4532c57f9b28
  ```

- **Failure degrades, never breaks**: pre-signed URLs expire, so a failed auto-fetch logs the error (`downloaded: false` + `download_error` in the payload) and the viewer still builds with the honest empty-preview note — a `view` that worked yesterday never starts exiting non-zero. Explicit `--download` keeps the strict contract: failed fetch and non-URL items stay errors.
- **`--no-download` suppresses** the fetch on both commands; previews then stay empty with the existing remediation note (reworded as a retry action, since the flag no longer needs discovering).
- **`ade crop` gets the same flow**: detect → notice → fetch before rendering. A failed fetch is the crop's failure (no empty-imagery fallback exists), exactly as the no-copy state already was.
- **Contract restated** in `attach.py`: a URL fetch is never *silent* — either asked for at parse time (`--keep-copy`) or announced before it starts. README, `--keep-copy`/`view`/`crop` help text, payload reference, and remediation hints updated to match.

## Verification

- 701 tests pass (new coverage: auto-fetch success/failure/skip for view, stderr notice + progress assertions, crop auto-fetch success/failure, `--download` strictness on both commands); ruff and `ty check src` clean; help reference regenerated.
- Verified end-to-end against a seeded store with a throttled localhost server under a real pty: notice renders, progress ticks 0→100%, previews embed in the same run, second run fetches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)