### PR TITLE
chore: bump version to 1.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ade-cli"
-version = "1.0.3"
+version = "1.0.4"
 description = "CLI for Agentic Document Extraction (ADE) — parse and extract documents with the v2 APIs, backed by a local store"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ade-cli"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bumps `pyproject.toml` and `uv.lock` to 1.0.4 (minimal two-line diff; the lockfile edit is validated by `uv sync --locked`, full suite green, `ade version` reports 1.0.4).

## ⚠️ Merge order

**Merge #177 first, then this PR** — v1.0.4 is intended to include:

- #177 — fix: auto-download URL-sourced documents on view/crop with notice and progress
- #176 — feat: live production integration suite gates the release (already on main)

Once both are in, cut the release via **Actions → Release → "Run workflow"** on `main`. The pipeline will run the live integration suite (macOS + Windows, against production) before tagging `v1.0.4` — first exercised green on run [31072130505](https://github.com/landing-ai/ade-cli/actions/runs/31072130505).

🤖 Generated with [Claude Code](https://claude.com/claude-code)