### PR TITLE
feat: organization selection for browser OAuth logins via x-org-id (ADR-0009)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 dist/
 build/
 .claude/settings.local.json
+*.log

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,8 +109,12 @@ _Avoid_: validation against a dedicated auth route (none exists in the v2 contra
 The per-environment Logto coordinates the browser login runs against: issuer (`login.*`, never the `logto.*` admin portal), client id, and the RFC 8707 resource indicator (the token audience — the environment's API endpoint). Defaults are data; `config.json`'s `oauth.<environment>` block overrides field by field. Browser login is a public login method (ADR-0008; ADR-0004's launch gate is deleted now that the platform accepts OIDC tokens).
 
 **OAuth session**:
-The refreshable browser-login credential for one environment: access + refresh tokens, identity, expiry. Access tokens refresh silently near expiry or once after a 401; refresh tokens rotate on every use, so refresh holds a cross-process lock and re-reads before spending one.
+The refreshable browser-login credential for one environment: access + refresh tokens, identity, expiry, and the organization selection. Access tokens refresh silently near expiry or once after a 401; refresh tokens rotate on every use, so refresh holds a cross-process lock and re-reads before spending one.
 _Avoid_: token (alone — access and refresh tokens have different lifecycles)
+
+**Organization selection**:
+Which Logto organization an OAuth session acts in (ADR-0009), stored per environment on the session and sent as `x-org-id` on API requests — the platform verifies membership per request. Memberships are discovered from Logto's userinfo (one resource-less refresh mints the opaque token userinfo accepts); one membership selects itself, several prompt or take `--org`, and no selection means the platform's default organization applies. `auth org list` / `auth org switch` manage it without a browser round-trip. API keys carry no selection — they are already organization-bound.
+_Avoid_: "logged into an org" (the token is organization-blind; the header carries the choice)
 
 ### Store
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ it — a mistyped key fails right at login, not at your first `parse`.
 If your account belongs to one organization, browser sign-in selects it
 automatically; if it belongs to several, the login asks (or takes
 `--org`), and `ade auth org switch` changes it any time without a
-browser round-trip. API keys belong to an organization already, so none
-of this applies to them.
+browser round-trip. Requests run — and bill — in the selected
+organization. An API key needs no selection and accepts none: it acts
+in the organization it was created in, so to work in a different
+organization with keys, create a key there and log in with that one.
 
 **There is no "current environment" — the target is resolved fresh on every
 command**: the `--env` flag, else the `ADE_ENV` variable, else `production`.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ stderr; set `ADE_NO_UPDATE_CHECK=1` to turn that off.
 | `ade auth login --api-key -` | prompt for the key (hidden input) |
 | `echo $KEY \| ade auth login` | headless: a piped key is the prompt, answered |
 | `ade auth login --env eu` | log in to the EU region (no-op if it already holds a credential) |
+| `ade auth login --org acme` | browser sign-in acting in a specific organization (id or name) |
 | `ade auth status` | the resolved target + every other environment holding a credential |
+| `ade auth org list` | your organizations, live, marking the selected one |
+| `ade auth org switch acme` | act in a different organization — no re-login needed |
 | `ade auth logout` | log out of the resolved target |
 | `ade auth logout --env eu` | log out of a specific environment |
 | `ade auth logout --all` | log out of every environment |
@@ -81,6 +84,12 @@ stores refreshable tokens; nothing to copy. API keys come from your
 [LandingAI account settings](https://ade.landing.ai/settings/api-key).
 `login` verifies the key against the target environment before storing
 it — a mistyped key fails right at login, not at your first `parse`.
+
+If your account belongs to one organization, browser sign-in selects it
+automatically; if it belongs to several, the login asks (or takes
+`--org`), and `ade auth org switch` changes it any time without a
+browser round-trip. API keys belong to an organization already, so none
+of this applies to them.
 
 **There is no "current environment" — the target is resolved fresh on every
 command**: the `--env` flag, else the `ADE_ENV` variable, else `production`.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ stderr; set `ADE_NO_UPDATE_CHECK=1` to turn that off.
 | `ade auth status` | the resolved target + every other environment holding a credential |
 | `ade auth org list` | your organizations, live, marking the selected one |
 | `ade auth org switch acme` | act in a different organization — no re-login needed |
+| `ade auth org clear` | drop the selection, falling back to the platform default |
 | `ade auth logout` | log out of the resolved target |
 | `ade auth logout --env eu` | log out of a specific environment |
 | `ade auth logout --all` | log out of every environment |

--- a/SKILL.md
+++ b/SKILL.md
@@ -23,7 +23,13 @@ Prefer it over N `--help` round trips. `ade help workflow` (also
 `output`, `credentials`, `errors`) is the conceptual page behind it.
 Check credentials with `ade auth status --json`; if logged out, set
 `ADE_API_KEY`, or pipe a key in (`echo $KEY | ade auth login`) — no
-terminal required either way.
+terminal required either way. An API key acts in the organization it
+was created in; browser (OAuth) sessions carry their own selection —
+`status` reports it, `ade auth org list --json` shows the memberships,
+and `ade auth org switch <org> --env <env>` changes it. If a run must
+bill to a specific organization, confirm the selection *before*
+parsing: re-running the same invocation after a switch joins the
+recorded run instead of re-billing under the new organization.
 
 ## Conventions
 

--- a/docs/adr/0009-org-selection-rides-x-org-id.md
+++ b/docs/adr/0009-org-selection-rides-x-org-id.md
@@ -1,0 +1,62 @@
+# ADR-0009: Organization selection rides `x-org-id`, not Logto organization tokens
+
+Date: 2026-08-07 · Status: accepted
+
+## Context
+
+A browser login's access token is organization-blind: the CLI requests
+no organization at the token grant, so the platform attributes every
+request to the account's server-side default organization (its
+`migratedOrgId`). Users who belong to several Logto organizations have
+no way to choose — a bug for any multi-org account.
+
+Two transports could carry a selection:
+
+1. **A request header.** The platform's authz already honors `x-org-id`
+   for user-scoped credentials (OIDC access tokens and PATs), verifying
+   membership on every request. No server change needed.
+2. **Logto organization tokens.** Mint the access token with the
+   `organization_id` grant parameter, putting the org in a *signed*
+   claim, with membership enforced by Logto at mint time. Requires the
+   platform's authz to read the claim — a change it has not shipped.
+
+Both need the same CLI work (the organizations scope, discovery via
+userinfo, a stored selection, a switch command); they differ only in
+transport. The header is re-verified per request (a removed member fails
+immediately); the claim is cheaper server-side and auditable in the
+token, but stale for up to a token lifetime after a membership change.
+
+## Decision
+
+The selection rides the `x-org-id` header (option 1), stored on the
+OAuth session as `organization: {id, name}` in `credentials.json` and
+sent by the gateway on every API request. API keys never send it — they
+are already organization-bound.
+
+Discovery is Logto's userinfo: login requests
+`urn:logto:scope:organizations`, then spends one refresh **without** the
+RFC 8707 resource indicator (the API-audience JWT is unwelcome at
+userinfo; only the opaque token gets in) and reads the `organizations` /
+`organization_data` claims. One membership selects itself; several
+prompt on a terminal or defer to `--org`; discovery failing never fails
+a login — the platform default applies until `auth org switch` sets one.
+Sessions predating the scope change discover nothing (the claim is
+absent, not empty) and are told to re-login.
+
+## Consequences
+
+- Selection and switching work with zero platform changes; membership
+  stays server-verified per request, so a forged or stale header cannot
+  cross an org boundary.
+- Flip condition, recorded now: when the platform's authz reads the
+  `organization_id` claim from verified OIDC tokens, the CLI should move
+  the transport to the token grant (`organization_id` parameter) and
+  drop the header. Nothing user-visible changes — the stored selection,
+  discovery, and commands all stay.
+- The platform's shadow authz service ignores `x-org-id` today
+  (comparison noise, no runtime effect); flagged to the platform team as
+  a cutover prerequisite.
+- Every browser login costs two extra Logto round-trips (the
+  resource-less refresh, userinfo). Refresh-token rotation makes the
+  discovery refresh a real spend: the rotated token is persisted under
+  the same cross-process lock as every other refresh.

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -38,6 +38,13 @@
           "help": "Log in with this API key directly ('-' prompts with hidden input)."
         },
         {
+          "flags": "--org",
+          "metavar": "TEXT",
+          "required": false,
+          "default": null,
+          "help": "Act in this Logto organization (id or name). Browser (OAuth) logins only \u2014 API keys are already organization-bound."
+        },
+        {
           "flags": "--env",
           "metavar": "TEXT",
           "required": false,
@@ -80,6 +87,10 @@
           {
             "key": "identity",
             "what": "OAuth logins: the token's identity claims"
+          },
+          {
+            "key": "organization",
+            "what": "OAuth logins: the selected organization ({id, name}; null when the platform default applies)"
           }
         ]
       },
@@ -128,7 +139,7 @@
             "what": "every other environment holding a credential"
           },
           {
-            "key": "expires_at / expires_in_seconds / refresh_token",
+            "key": "expires_at / expires_in_seconds / refresh_token / organization",
             "what": "OAuth only"
           }
         ]
@@ -185,6 +196,84 @@
       "band": "credentials & CLI lifecycle"
     },
     {
+      "name": "auth org list",
+      "usage": "ade auth org list [options] [--json]",
+      "summary": "List the organizations the target's OAuth session can act in,\nmarking the selected one. Memberships come live from the login\nprovider, so a fresh grant or removal shows immediately.",
+      "arguments": [],
+      "flags": [
+        {
+          "flags": "--env",
+          "metavar": "TEXT",
+          "required": false,
+          "default": null,
+          "help": "Environment to target: dev, staging, production, eu (default: $ADE_ENV, then production). Credentials are stored per environment."
+        }
+      ],
+      "supports_json": true,
+      "result": {
+        "shape": "object",
+        "keys": [
+          {
+            "key": "organizations",
+            "what": "your memberships, live from the login provider: [{id, name, selected}]"
+          },
+          {
+            "key": "selected",
+            "what": "the selected organization id (null when the platform default applies)"
+          },
+          {
+            "key": "environment",
+            "what": "the resolved target"
+          }
+        ]
+      },
+      "band": "credentials & CLI lifecycle"
+    },
+    {
+      "name": "auth org switch",
+      "usage": "ade auth org switch ORG [options] [--json]",
+      "summary": "Switch which organization the target's OAuth session acts in.\nValidated against your live memberships here, and membership-verified\nby the platform on every request regardless.",
+      "arguments": [
+        {
+          "name": "ORG",
+          "required": true,
+          "help": "Organization id or name."
+        }
+      ],
+      "flags": [
+        {
+          "flags": "--env",
+          "metavar": "TEXT",
+          "required": false,
+          "default": null,
+          "help": "Environment to target: dev, staging, production, eu (default: $ADE_ENV, then production). Credentials are stored per environment."
+        }
+      ],
+      "supports_json": true,
+      "result": {
+        "shape": "object",
+        "keys": [
+          {
+            "key": "organization",
+            "what": "the selection now stored ({id, name})"
+          },
+          {
+            "key": "previous",
+            "what": "the selection it replaced (null if none)"
+          },
+          {
+            "key": "stored",
+            "what": "always true on success"
+          },
+          {
+            "key": "environment",
+            "what": "the resolved target"
+          }
+        ]
+      },
+      "band": "credentials & CLI lifecycle"
+    },
+    {
       "name": "login",
       "usage": "ade login [options] [--json]",
       "summary": "Alias of `ade auth login`: ensure the target environment is logged in; --api-key authenticates with a key directly ('-' prompts with hidden input).",
@@ -196,6 +285,13 @@
           "required": false,
           "default": null,
           "help": "Log in with this API key directly ('-' prompts with hidden input)."
+        },
+        {
+          "flags": "--org",
+          "metavar": "TEXT",
+          "required": false,
+          "default": null,
+          "help": "Act in this Logto organization (id or name). Browser (OAuth) logins only \u2014 API keys are already organization-bound."
         },
         {
           "flags": "--env",
@@ -240,6 +336,10 @@
           {
             "key": "identity",
             "what": "OAuth logins: the token's identity claims"
+          },
+          {
+            "key": "organization",
+            "what": "OAuth logins: the selected organization ({id, name}; null when the platform default applies)"
           }
         ]
       },
@@ -1252,7 +1352,14 @@
         "  ade auth login --api-key $KEY    inline (visible to `ps`)",
         "",
         "`ade auth status --json` reports the resolved target, how it is",
-        "authenticated, and every other environment holding a credential."
+        "authenticated, and every other environment holding a credential.",
+        "",
+        "Browser (OAuth) logins act in one Logto organization: a single",
+        "membership selects itself; several prompt at login (or take",
+        "--org). `ade auth org list` shows the memberships live, and",
+        "`ade auth org switch <org>` changes the selection without a",
+        "re-login. No selection means the platform default applies. API",
+        "keys are already organization-bound \u2014 none of this applies."
       ]
     },
     {

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -198,7 +198,7 @@
     {
       "name": "auth org list",
       "usage": "ade auth org list [options] [--json]",
-      "summary": "List the organizations the target's OAuth session can act in,\nmarking the selected one. Memberships come live from the login\nprovider, so a fresh grant or removal shows immediately.",
+      "summary": "List the organizations the target's OAuth session can act in,\nmarking the selected one. Memberships come live from the login\nprovider, so a fresh grant or removal shows immediately \u2014 including a\nselection that is no longer a membership.",
       "arguments": [],
       "flags": [
         {
@@ -220,6 +220,10 @@
           {
             "key": "selected",
             "what": "the selected organization id (null when the platform default applies)"
+          },
+          {
+            "key": "selected_is_stale",
+            "what": "true when the selection is no longer one of your memberships \u2014 requests still send it and the platform rejects them; switch or clear"
           },
           {
             "key": "environment",
@@ -264,6 +268,44 @@
           {
             "key": "stored",
             "what": "always true on success"
+          },
+          {
+            "key": "environment",
+            "what": "the resolved target"
+          }
+        ]
+      },
+      "band": "credentials & CLI lifecycle"
+    },
+    {
+      "name": "auth org clear",
+      "usage": "ade auth org clear [options] [--json]",
+      "summary": "Drop the target's organization selection, falling back to the\nplatform default. Idempotent, and deliberately offline: this is the\nway out when a selection has outlived its membership, which is\nexactly when listing memberships may not work.",
+      "arguments": [],
+      "flags": [
+        {
+          "flags": "--env",
+          "metavar": "TEXT",
+          "required": false,
+          "default": null,
+          "help": "Environment to target: dev, staging, production, eu (default: $ADE_ENV, then production). Credentials are stored per environment."
+        }
+      ],
+      "supports_json": true,
+      "result": {
+        "shape": "object",
+        "keys": [
+          {
+            "key": "organization",
+            "what": "always null \u2014 the platform default now applies"
+          },
+          {
+            "key": "previous",
+            "what": "the selection that was dropped (null if none)"
+          },
+          {
+            "key": "cleared",
+            "what": "false when there was nothing selected"
           },
           {
             "key": "environment",
@@ -1356,9 +1398,11 @@
         "",
         "Browser (OAuth) logins act in one Logto organization: a single",
         "membership selects itself; several prompt at login (or take",
-        "--org). `ade auth org list` shows the memberships live, and",
+        "--org). `ade auth org list` shows the memberships live (and",
+        "flags a selection that is no longer one of them),",
         "`ade auth org switch <org>` changes the selection without a",
-        "re-login. Requests run \u2014 and bill \u2014 in the selected",
+        "re-login, and `ade auth org clear` falls back to the platform",
+        "default. Requests run \u2014 and bill \u2014 in the selected",
         "organization; none selected means the platform default applies.",
         "An API key needs no selection and accepts none: it acts in the",
         "organization it was created in."

--- a/docs/reference/help.json
+++ b/docs/reference/help.json
@@ -1358,8 +1358,10 @@
         "membership selects itself; several prompt at login (or take",
         "--org). `ade auth org list` shows the memberships live, and",
         "`ade auth org switch <org>` changes the selection without a",
-        "re-login. No selection means the platform default applies. API",
-        "keys are already organization-bound \u2014 none of this applies."
+        "re-login. Requests run \u2014 and bill \u2014 in the selected",
+        "organization; none selected means the platform default applies.",
+        "An API key needs no selection and accepts none: it acts in the",
+        "organization it was created in."
       ]
     },
     {

--- a/src/ade_cli/auth.py
+++ b/src/ade_cli/auth.py
@@ -27,6 +27,14 @@ own checks diagnose a headless environment.
 ``logout`` de-auths one environment (the resolved target by default;
 ``--all`` clears every environment). ``status`` reports the resolved
 target plus every other environment holding a credential.
+
+Browser logins carry an organization selection (ADR-0009): memberships
+are discovered from Logto's userinfo after the token exchange, the
+selection is stored on the OAuth session, and it rides ``x-org-id`` on
+API requests (membership-verified by the platform per request). One
+membership selects itself; several prompt on a terminal (``--org`` picks
+without one); discovery failing never fails a login — the platform
+default organization applies until ``auth org switch`` sets one.
 """
 
 from __future__ import annotations
@@ -39,6 +47,7 @@ import typer
 
 from . import credentials, filelock, gateway, oauth, term
 from .config import (
+    DEFAULT_ENVIRONMENT,
     ENVIRONMENTS,
     ResolvedConfig,
     ade_home,
@@ -70,6 +79,12 @@ def login(
         help="Log in with this API key directly "
         "('-' prompts with hidden input).",
     ),
+    org: str | None = typer.Option(
+        None,
+        "--org",
+        help="Act in this Logto organization (id or name). Browser "
+        "(OAuth) logins only — API keys are already organization-bound.",
+    ),
     environment: str | None = typer.Option(None, "--env", help=_ENV_HELP),
     as_json: bool = JSON_FLAG,
 ) -> None:
@@ -79,8 +94,20 @@ def login(
     about the choice."""
     home = ade_home()
     resolved = resolve_target(home, environment, as_json=as_json)
+    if api_key is not None and org is not None:
+        exit_with(
+            {
+                "error": "org_with_api_key",
+                "message": "--org applies to browser (OAuth) logins; API "
+                "keys are already organization-bound.",
+            },
+            "--org applies to browser (OAuth) logins; API keys are already "
+            "organization-bound.",
+            as_json=as_json,
+            code=EXIT_USAGE,
+        )
     if api_key is None:
-        _login_without_key(ctx.obj, home, resolved, as_json=as_json)
+        _login_without_key(ctx.obj, home, resolved, org=org, as_json=as_json)
         return
 
     if api_key == "-":
@@ -227,16 +254,26 @@ def _verify_api_key(
 
 
 def _login_without_key(
-    ports: Ports, home, resolved: ResolvedConfig, *, as_json: bool
+    ports: Ports, home, resolved: ResolvedConfig, *, org: str | None, as_json: bool
 ) -> None:
     """No credential flag: *ensure* logged in on the target. A stored
     credential means there is nothing to do (credentials are per
-    environment; no selection exists to change). Otherwise acquire one —
-    a terminal prompts (the ADR-0002 method menu); a non-interactive run
-    takes a key piped on stdin, else the browser flow."""
+    environment; no selection exists to change) — unless --org names an
+    organization, which the guarantee then ensures too. Otherwise acquire
+    one — a terminal prompts (the ADR-0002 method menu); a non-interactive
+    run takes a key piped on stdin, else the browser flow. --org implies
+    the browser method, so it skips both the pipe and the menu."""
     existing = credentials.stored_credential(home, resolved.environment)
     if existing is not None:
+        if org is not None:
+            _ensure_org_on_existing(
+                ports, home, resolved, existing, org, as_json=as_json
+            )
+            return
         _emit_already(home, resolved, existing, as_json=as_json)
+        return
+    if org is not None:
+        _browser_login(ports, home, resolved, org=org, as_json=as_json)
         return
     # A key piped in is a prompt answered ahead of time — the headless
     # spelling of the same gesture (F2) — and it wins *before* the menu:
@@ -358,11 +395,225 @@ def _emit_already(
 
 
 def _browser_login(
-    ports: Ports, home, resolved: ResolvedConfig, *, as_json: bool
+    ports: Ports,
+    home,
+    resolved: ResolvedConfig,
+    *,
+    org: str | None = None,
+    as_json: bool,
 ) -> None:
     entry = _run_browser_flow(ports, home, resolved, as_json=as_json)
     credentials.store_oauth(home, resolved.environment, entry)
-    _emit_browser_login(home, resolved, entry, as_json=as_json)
+    # Tokens are durable before the org pick starts: a failed or skipped
+    # selection degrades to the platform default, never to a lost login.
+    organization, note = _select_org_after_login(
+        ports, home, resolved, requested=org, as_json=as_json
+    )
+    _emit_browser_login(
+        home, resolved, entry, organization=organization, note=note, as_json=as_json
+    )
+
+
+def _org_switch_hint(resolved: ResolvedConfig) -> str:
+    """The `auth org switch` invocation for *this* target, mirroring
+    login_hint's --env rule."""
+    suffix = (
+        f" --env {resolved.environment}"
+        if resolved.environment != DEFAULT_ENVIRONMENT
+        else ""
+    )
+    return f"ade auth org switch <org>{suffix}"
+
+
+def _select_org_after_login(
+    ports: Ports,
+    home,
+    resolved: ResolvedConfig,
+    *,
+    requested: str | None,
+    as_json: bool,
+) -> tuple[dict | None, str | None]:
+    """The post-login org pick: (selection, note-for-humans). An explicit
+    --org that cannot be honored fails the command (the user asked for a
+    state the login didn't reach — though the tokens are stored); the
+    automatic pick degrades to a note instead, because a login must never
+    be lost to a discovery hiccup."""
+    try:
+        organizations = oauth.fetch_organizations(home, resolved.environment, ports)
+    except oauth.OrgDiscoveryError as error:
+        if requested is not None:
+            exit_with(
+                {
+                    "error": f"org_{error.reason}",
+                    "message": error.message,
+                    "stored": True,
+                },
+                f"Logged in, but selecting an organization failed: "
+                f"{error.message}. The tokens are stored; run "
+                f"`{_org_switch_hint(resolved)}` once the problem is fixed.",
+                as_json=as_json,
+                code=EXIT_FAILED,
+            )
+        return None, (
+            f"Organization discovery failed ({error.message}); the platform "
+            f"default applies. Select one later with "
+            f"`{_org_switch_hint(resolved)}`."
+        )
+    if requested is not None:
+        organization = _match_org(
+            organizations, requested, resolved=resolved, as_json=as_json
+        )
+        oauth.set_organization(home, resolved.environment, organization)
+        return organization, None
+    if not organizations:
+        return None, None
+    if len(organizations) == 1:
+        oauth.set_organization(home, resolved.environment, organizations[0])
+        return organizations[0], None
+    organization = _prompt_org_choice(ports, organizations)
+    if organization is None:
+        return None, (
+            "Your account belongs to multiple organizations; none was "
+            "selected, so the platform default applies. Choose one with "
+            f"`{_org_switch_hint(resolved)}`."
+        )
+    oauth.set_organization(home, resolved.environment, organization)
+    return organization, None
+
+
+def _org_label(organization: dict) -> str:
+    name = organization.get("name") or organization["id"]
+    if name == organization["id"]:
+        return organization["id"]
+    return f"{name} ({organization['id']})"
+
+
+def _prompt_org_choice(ports: Ports, organizations: list[dict]) -> dict | None:
+    """The org menu, shaped like the login-method menu: arrow-key pointer
+    on a real terminal, a numbered typed prompt as the fallback. Without
+    an interactive stdin there is nobody to ask — return None and let the
+    caller leave the platform default in place."""
+    if not ports.stdin_is_tty():
+        return None
+    labels = [_org_label(organization) for organization in organizations]
+    if os.environ.get("TERM") != "dumb":
+        typer.echo(
+            "Which organization should this login act in? (↑/↓ and Enter)",
+            err=True,
+        )
+        try:
+            index = term.select(labels, getchar=ports.getchar)
+            return organizations[index]
+        except term.Unsupported:
+            pass  # the widget erased itself; the typed fallback re-lists
+    else:
+        typer.echo("Which organization should this login act in?", err=True)
+    for number, label in enumerate(labels, start=1):
+        typer.echo(f"  {number}) {label}", err=True)
+    while True:
+        choice = typer.prompt("Organization", default="1", err=True).strip()
+        if choice.isdigit() and 1 <= int(choice) <= len(organizations):
+            return organizations[int(choice) - 1]
+        typer.echo(f"Choose 1-{len(organizations)}.", err=True)
+
+
+def _match_org(
+    organizations: list[dict],
+    requested: str,
+    *,
+    resolved: ResolvedConfig,
+    as_json: bool,
+) -> dict:
+    """Resolve an id-or-name to one membership: exact id first, then a
+    unique case-insensitive name. Anything else exits listing what the
+    account can actually act in (the server would reject it anyway —
+    x-org-id is membership-verified per request)."""
+    for organization in organizations:
+        if organization["id"] == requested:
+            return organization
+    by_name = [
+        organization
+        for organization in organizations
+        if (organization.get("name") or "").casefold() == requested.casefold()
+    ]
+    if len(by_name) == 1:
+        return by_name[0]
+    listed = ", ".join(_org_label(o) for o in organizations) or "none"
+    reason = "org_ambiguous" if len(by_name) > 1 else "org_not_found"
+    detail = (
+        f"{requested!r} names more than one organization — pass its id"
+        if len(by_name) > 1
+        else f"no organization of yours matches {requested!r}"
+    )
+    exit_with(
+        {
+            "error": reason,
+            "requested": requested,
+            "organizations": organizations,
+            "environment": resolved.environment,
+        },
+        f"Cannot select an organization: {detail}. Your organizations: "
+        f"{listed}.",
+        as_json=as_json,
+        code=EXIT_FAILED,
+    )
+
+
+def _ensure_org_on_existing(
+    ports: Ports,
+    home,
+    resolved: ResolvedConfig,
+    existing: credentials.ActiveCredential,
+    requested: str,
+    *,
+    as_json: bool,
+) -> None:
+    """`login --org X` against a target that is already logged in: the
+    guarantee extends to the organization, so an OAuth session switches
+    without a browser round-trip (the refresh token is org-agnostic)."""
+    if existing.method != "oauth" or existing.oauth is None:
+        exit_with(
+            {
+                "error": "org_with_api_key",
+                "message": "--org applies to browser (OAuth) logins; the "
+                "stored credential is an API key, which is already "
+                "organization-bound.",
+            },
+            "--org applies to browser (OAuth) logins; the stored credential "
+            "is an API key, which is already organization-bound. Log out "
+            "first to switch methods.",
+            as_json=as_json,
+            code=EXIT_USAGE,
+        )
+    try:
+        organizations = oauth.fetch_organizations(home, resolved.environment, ports)
+    except oauth.OrgDiscoveryError as error:
+        exit_with(
+            {"error": f"org_{error.reason}", "message": error.message},
+            f"Selecting an organization failed: {error.message}.",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    organization = _match_org(
+        organizations, requested, resolved=resolved, as_json=as_json
+    )
+    oauth.set_organization(home, resolved.environment, organization)
+    identity = existing.oauth.get("identity") or {}
+    who = identity.get("email") or identity.get("sub") or "unknown identity"
+    emit(
+        {
+            "method": "oauth",
+            "already_authenticated": True,
+            "organization": organization,
+            "stored": True,
+            "environment": resolved.environment,
+            "endpoint": resolved.endpoint,
+            "endpoint_source": resolved.endpoint_source,
+        },
+        f"Already authenticated for the {resolved.environment} environment "
+        f"as {who}; organization set to {_org_label(organization)}.",
+        as_json=as_json,
+    )
 
 
 def _run_browser_flow(
@@ -429,26 +680,40 @@ def _run_browser_flow(
 
 
 def _emit_browser_login(
-    home, resolved: ResolvedConfig, entry: dict, *, as_json: bool
+    home,
+    resolved: ResolvedConfig,
+    entry: dict,
+    *,
+    organization: dict | None = None,
+    note: str | None = None,
+    as_json: bool,
 ) -> None:
     identity = entry.get("identity") or {}
     who = identity.get("email") or identity.get("sub") or "unknown identity"
-    emit(
-        {
-            "method": "oauth",
-            "identity": identity,
-            "credential": credentials.mask(entry["access_token"]),
-            "stored": True,
-            "environment": resolved.environment,
-            "endpoint": resolved.endpoint,
-            "endpoint_source": resolved.endpoint_source,
-        },
+    human = (
         f"Logged in as {who} via browser (tokens stored in "
         f"{credentials.credentials_path(home)} for the "
         f"{resolved.environment} environment).\n"
-        f"Endpoint: {resolved.endpoint} ({resolved.endpoint_source})",
-        as_json=as_json,
+        f"Endpoint: {resolved.endpoint} ({resolved.endpoint_source})"
     )
+    if organization is not None:
+        human = f"{human}\nOrganization: {_org_label(organization)}"
+    if note is not None:
+        human = f"{human}\n{note}"
+    payload = {
+        "method": "oauth",
+        "identity": identity,
+        "credential": credentials.mask(entry["access_token"]),
+        "organization": organization,
+        "stored": True,
+        "environment": resolved.environment,
+        "endpoint": resolved.endpoint,
+        "endpoint_source": resolved.endpoint_source,
+    }
+    if note is not None:
+        # Agents read the JSON, so the remediation must live in it too.
+        payload["organization_note"] = note
+    emit(payload, human, as_json=as_json)
 
 
 def _expiry_note(oauth_entry: dict, ports: Ports) -> tuple[float | None, str]:
@@ -517,18 +782,26 @@ def status(
         identity = active.oauth.get("identity") or {}
         remaining, note = _expiry_note(active.oauth, ports)
         refresh = "available" if active.oauth.get("refresh_token") else "unavailable"
+        organization = active.oauth.get("organization")
         payload.update(
             {
                 "identity": identity,
                 "expires_at": active.oauth.get("expires_at"),
                 "expires_in_seconds": max(0, int(remaining)) if remaining is not None else None,
                 "refresh_token": refresh == "available",
+                "organization": organization,
             }
+        )
+        org_note = (
+            _org_label(organization)
+            if organization
+            else "platform default (none selected)"
         )
         who = identity.get("email") or identity.get("sub") or "unknown identity"
         human = (
             f"Authenticated via OAuth as {who} ({source_note}).\n"
             f"Access token {active.masked} {note}; refresh token {refresh}.\n"
+            f"Organization: {org_note}\n"
             f"{tail}"
         )
     else:
@@ -605,6 +878,151 @@ def logout(
     cleared = credentials.clear_environment(home, target)
     _emit_logout(
         cleared, revoked, scope="environment", environment=target, as_json=as_json
+    )
+
+
+org_app = typer.Typer(
+    name="org",
+    no_args_is_help=True,
+    help="Show or switch the organization an OAuth login acts in.",
+)
+auth_app.add_typer(org_app)
+
+
+def _require_oauth_session(home, resolved: ResolvedConfig, *, as_json: bool) -> dict:
+    """Org commands manage the *stored* OAuth session (ADE_API_KEY plays
+    no part): exit with remediation when the target has none."""
+    stored = credentials.stored_credential(home, resolved.environment)
+    if stored is None:
+        exit_with(
+            {
+                "error": "unauthenticated",
+                "environment": resolved.environment,
+                "message": f"Run `{resolved.login_hint}` first.",
+            },
+            f"Not authenticated for {resolved.endpoint_label}. Run "
+            f"`{resolved.login_hint}` first.",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    if stored.method != "oauth" or stored.oauth is None:
+        exit_with(
+            {
+                "error": "org_requires_oauth",
+                "environment": resolved.environment,
+                "message": "Organization selection applies to browser "
+                "(OAuth) logins; API keys are already organization-bound.",
+            },
+            "Organization selection applies to browser (OAuth) logins; the "
+            f"stored credential for {resolved.environment} is an API key, "
+            "which is already organization-bound. Log in with the browser "
+            f"method first (`{resolved.login_hint}`).",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+    return stored.oauth
+
+
+def _fetch_orgs_or_exit(
+    ports: Ports, home, resolved: ResolvedConfig, *, as_json: bool
+) -> list[dict]:
+    try:
+        return oauth.fetch_organizations(home, resolved.environment, ports)
+    except oauth.OrgDiscoveryError as error:
+        exit_with(
+            {
+                "error": f"org_{error.reason}",
+                "environment": resolved.environment,
+                "message": error.message,
+            },
+            f"Could not list your organizations: {error.message}.",
+            as_json=as_json,
+            code=EXIT_FAILED,
+        )
+
+
+@org_app.command("list")
+def org_list(
+    ctx: typer.Context,
+    environment: str | None = typer.Option(None, "--env", help=_ENV_HELP),
+    as_json: bool = JSON_FLAG,
+) -> None:
+    """List the organizations the target's OAuth session can act in,
+    marking the selected one. Memberships come live from the login
+    provider, so a fresh grant or removal shows immediately."""
+    home = ade_home()
+    ports: Ports = ctx.obj
+    resolved = resolve_target(home, environment, as_json=as_json)
+    entry = _require_oauth_session(home, resolved, as_json=as_json)
+    organizations = _fetch_orgs_or_exit(ports, home, resolved, as_json=as_json)
+    selected_id = ((entry.get("organization") or {}).get("id")) or None
+    rows = [
+        {**organization, "selected": organization["id"] == selected_id}
+        for organization in organizations
+    ]
+    if not rows:
+        human = (
+            "Your account belongs to no organizations; requests use the "
+            "platform default."
+        )
+    else:
+        lines = [
+            f"{'*' if row['selected'] else ' '} {_org_label(row)}" for row in rows
+        ]
+        human = "\n".join(lines)
+        if selected_id is None:
+            human = (
+                f"{human}\nNo organization selected; the platform default "
+                f"applies. Select one with `{_org_switch_hint(resolved)}`."
+            )
+    emit(
+        {
+            "environment": resolved.environment,
+            "organizations": rows,
+            "selected": selected_id,
+        },
+        human,
+        as_json=as_json,
+    )
+
+
+@org_app.command("switch")
+def org_switch(
+    ctx: typer.Context,
+    org: str = typer.Argument(..., help="Organization id or name."),
+    environment: str | None = typer.Option(None, "--env", help=_ENV_HELP),
+    as_json: bool = JSON_FLAG,
+) -> None:
+    """Switch which organization the target's OAuth session acts in.
+    Validated against your live memberships here, and membership-verified
+    by the platform on every request regardless."""
+    home = ade_home()
+    ports: Ports = ctx.obj
+    resolved = resolve_target(home, environment, as_json=as_json)
+    entry = _require_oauth_session(home, resolved, as_json=as_json)
+    previous = entry.get("organization") or None
+    organizations = _fetch_orgs_or_exit(ports, home, resolved, as_json=as_json)
+    organization = _match_org(organizations, org, resolved=resolved, as_json=as_json)
+    oauth.set_organization(home, resolved.environment, organization)
+    if previous and previous.get("id") == organization["id"]:
+        human = (
+            f"Already acting in {_org_label(organization)} for the "
+            f"{resolved.environment} environment; nothing to do."
+        )
+    else:
+        human = (
+            f"Now acting in {_org_label(organization)} for the "
+            f"{resolved.environment} environment."
+        )
+    emit(
+        {
+            "environment": resolved.environment,
+            "organization": organization,
+            "previous": previous,
+            "stored": True,
+        },
+        human,
+        as_json=as_json,
     )
 
 

--- a/src/ade_cli/auth.py
+++ b/src/ade_cli/auth.py
@@ -382,9 +382,19 @@ def _emit_already(
         identity = cred.oauth.get("identity") or {}
         who = identity.get("email") or identity.get("sub") or "unknown identity"
         payload["identity"] = identity
+        # The published `auth login` shape promises `organization` on every
+        # OAuth result, so the no-op path carries it too — null included,
+        # since agents read the shape rather than discovering it.
+        organization = cred.oauth.get("organization") or None
+        payload["organization"] = organization
+        org_note = (
+            _org_label(organization)
+            if organization
+            else "platform default (none selected)"
+        )
         human = (
             f"Already authenticated for the {resolved.environment} environment "
-            f"as {who}; nothing to do.\n{tail}"
+            f"as {who}; nothing to do.\nOrganization: {org_note}\n{tail}"
         )
     else:
         human = (
@@ -414,15 +424,21 @@ def _browser_login(
     )
 
 
+def _org_env_suffix(resolved: ResolvedConfig) -> str:
+    """`--env X` for a non-default target, mirroring login_hint's rule."""
+    if resolved.environment != DEFAULT_ENVIRONMENT:
+        return f" --env {resolved.environment}"
+    return ""
+
+
 def _org_switch_hint(resolved: ResolvedConfig) -> str:
-    """The `auth org switch` invocation for *this* target, mirroring
-    login_hint's --env rule."""
-    suffix = (
-        f" --env {resolved.environment}"
-        if resolved.environment != DEFAULT_ENVIRONMENT
-        else ""
-    )
-    return f"ade auth org switch <org>{suffix}"
+    """The `auth org switch` invocation for *this* target."""
+    return f"ade auth org switch <org>{_org_env_suffix(resolved)}"
+
+
+def _org_clear_hint(resolved: ResolvedConfig) -> str:
+    """The `auth org clear` invocation for *this* target."""
+    return f"ade auth org clear{_org_env_suffix(resolved)}"
 
 
 def _select_org_after_login(
@@ -949,7 +965,8 @@ def org_list(
 ) -> None:
     """List the organizations the target's OAuth session can act in,
     marking the selected one. Memberships come live from the login
-    provider, so a fresh grant or removal shows immediately."""
+    provider, so a fresh grant or removal shows immediately — including a
+    selection that is no longer a membership."""
     home = ade_home()
     ports: Ports = ctx.obj
     resolved = resolve_target(home, environment, as_json=as_json)
@@ -960,28 +977,35 @@ def org_list(
         {**organization, "selected": organization["id"] == selected_id}
         for organization in organizations
     ]
+    # A selection can outlive the membership behind it (removed from the
+    # org, org deleted). The header keeps going out until it is changed,
+    # and the platform rejects it — so say so instead of reporting a
+    # default that is not what requests actually carry.
+    stale = selected_id is not None and not any(row["selected"] for row in rows)
+    lines = [f"{'*' if row['selected'] else ' '} {_org_label(row)}" for row in rows]
     if not rows:
-        human = (
-            "Your account belongs to no organizations; requests use the "
-            "platform default."
+        lines = ["Your account belongs to no organizations."]
+    if stale:
+        lines.append(
+            f"Selected organization {selected_id} is no longer one of your "
+            f"memberships: requests still send it and the platform will "
+            f"reject them. Pick another with `{_org_switch_hint(resolved)}`, "
+            f"or fall back to the platform default with "
+            f"`{_org_clear_hint(resolved)}`."
         )
-    else:
-        lines = [
-            f"{'*' if row['selected'] else ' '} {_org_label(row)}" for row in rows
-        ]
-        human = "\n".join(lines)
-        if selected_id is None:
-            human = (
-                f"{human}\nNo organization selected; the platform default "
-                f"applies. Select one with `{_org_switch_hint(resolved)}`."
-            )
+    elif selected_id is None:
+        lines.append(
+            "No organization selected; the platform default applies."
+            + (f" Select one with `{_org_switch_hint(resolved)}`." if rows else "")
+        )
     emit(
         {
             "environment": resolved.environment,
             "organizations": rows,
             "selected": selected_id,
+            "selected_is_stale": stale,
         },
-        human,
+        "\n".join(lines),
         as_json=as_json,
     )
 
@@ -1020,6 +1044,40 @@ def org_switch(
             "organization": organization,
             "previous": previous,
             "stored": True,
+        },
+        human,
+        as_json=as_json,
+    )
+
+
+@org_app.command("clear")
+def org_clear(
+    ctx: typer.Context,
+    environment: str | None = typer.Option(None, "--env", help=_ENV_HELP),
+    as_json: bool = JSON_FLAG,
+) -> None:
+    """Drop the target's organization selection, falling back to the
+    platform default. Idempotent, and deliberately offline: this is the
+    way out when a selection has outlived its membership, which is
+    exactly when listing memberships may not work."""
+    home = ade_home()
+    resolved = resolve_target(home, environment, as_json=as_json)
+    entry = _require_oauth_session(home, resolved, as_json=as_json)
+    previous = entry.get("organization") or None
+    oauth.set_organization(home, resolved.environment, None)
+    human = (
+        f"Cleared the organization selection for the {resolved.environment} "
+        f"environment ({_org_label(previous)} → platform default)."
+        if previous
+        else f"No organization was selected for the {resolved.environment} "
+        "environment; nothing to do."
+    )
+    emit(
+        {
+            "environment": resolved.environment,
+            "organization": None,
+            "previous": previous,
+            "cleared": previous is not None,
         },
         human,
         as_json=as_json,

--- a/src/ade_cli/credentials.py
+++ b/src/ade_cli/credentials.py
@@ -38,6 +38,21 @@ class ActiveCredential:
     def masked(self) -> str:
         return mask(self.secret)
 
+    @property
+    def org_id(self) -> str | None:
+        """The OAuth session's selected organization id (ADR-0009), sent
+        as ``x-org-id`` on API requests. None for API keys (already
+        organization-bound) and for sessions with no selection (the
+        platform default organization applies)."""
+        if self.oauth is None:
+            return None
+        organization = self.oauth.get("organization")
+        if isinstance(organization, dict):
+            value = organization.get("id")
+            if isinstance(value, str) and value:
+                return value
+        return None
+
 
 def mask(secret: str) -> str:
     if len(secret) <= 8:

--- a/src/ade_cli/extract.py
+++ b/src/ade_cli/extract.py
@@ -457,6 +457,7 @@ def extract(
         auth=oauth.bearer_auth(home, resolved, active, ports),
         transport=ports.transport,
         command="extract",
+        org_id=active.org_id,
     )
 
     if parse_first is not None:

--- a/src/ade_cli/gateway.py
+++ b/src/ade_cli/gateway.py
@@ -137,6 +137,14 @@ def verify_credential(
         _check(client.post(TELEMETRY_PATH, json=[]), (200,))
 
 
+# The OAuth session's organization selection (ADR-0009). A user-scoped
+# bearer token is organization-blind, so the platform's authz reads this
+# header and verifies membership per request; without it, requests fall
+# to the account's platform-side default organization. API keys are
+# already organization-bound — callers pass no org and no header is sent.
+ORG_ID_HEADER = "x-org-id"
+
+
 class BearerAuth(Protocol):
     """Where the Authorization header comes from, request by request."""
 
@@ -168,6 +176,9 @@ class Gateway:
     # ``command/<name>`` token — the invoking command, so a parse job run
     # inside `extract -d` still says command/extract.
     command: str
+    # The selected organization id (OAuth sessions only; ADR-0009), sent
+    # as ORG_ID_HEADER on every request.
+    org_id: str | None = None
 
     def _send(
         self,
@@ -189,6 +200,7 @@ class Gateway:
                 # relays X-Source verbatim into the recorded row's source
                 # column, distinguishing CLI rows from raw-API ones.
                 "X-Source": "cli",
+                **({ORG_ID_HEADER: self.org_id} if self.org_id else {}),
             },
         ) as client:
             client.headers["Authorization"] = f"Bearer {self.auth.token()}"

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -51,6 +51,7 @@ BANDS: list[tuple[str, list[str]]] = [
             "auth logout",
             "auth org list",
             "auth org switch",
+            "auth org clear",
             "login",
             "logout",
             "version",
@@ -143,9 +144,11 @@ TOPICS: list[dict] = [
             "",
             "Browser (OAuth) logins act in one Logto organization: a single",
             "membership selects itself; several prompt at login (or take",
-            "--org). `ade auth org list` shows the memberships live, and",
+            "--org). `ade auth org list` shows the memberships live (and",
+            "flags a selection that is no longer one of them),",
             "`ade auth org switch <org>` changes the selection without a",
-            "re-login. Requests run — and bill — in the selected",
+            "re-login, and `ade auth org clear` falls back to the platform",
+            "default. Requests run — and bill — in the selected",
             "organization; none selected means the platform default applies.",
             "An API key needs no selection and accepts none: it acts in the",
             "organization it was created in.",
@@ -342,6 +345,9 @@ RESULTS: dict[str, dict] = {
              "provider: [{id, name, selected}]"),
             ("selected", "the selected organization id (null when the "
              "platform default applies)"),
+            ("selected_is_stale", "true when the selection is no longer one "
+             "of your memberships — requests still send it and the platform "
+             "rejects them; switch or clear"),
             ("environment", "the resolved target"),
         ],
     },
@@ -351,6 +357,15 @@ RESULTS: dict[str, dict] = {
             ("organization", "the selection now stored ({id, name})"),
             ("previous", "the selection it replaced (null if none)"),
             ("stored", "always true on success"),
+            ("environment", "the resolved target"),
+        ],
+    },
+    "auth org clear": {
+        "shape": "object",
+        "keys": [
+            ("organization", "always null — the platform default now applies"),
+            ("previous", "the selection that was dropped (null if none)"),
+            ("cleared", "false when there was nothing selected"),
             ("environment", "the resolved target"),
         ],
     },

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -49,6 +49,8 @@ BANDS: list[tuple[str, list[str]]] = [
             "auth login",
             "auth status",
             "auth logout",
+            "auth org list",
+            "auth org switch",
             "login",
             "logout",
             "version",
@@ -138,6 +140,13 @@ TOPICS: list[dict] = [
             "",
             "`ade auth status --json` reports the resolved target, how it is",
             "authenticated, and every other environment holding a credential.",
+            "",
+            "Browser (OAuth) logins act in one Logto organization: a single",
+            "membership selects itself; several prompt at login (or take",
+            "--org). `ade auth org list` shows the memberships live, and",
+            "`ade auth org switch <org>` changes the selection without a",
+            "re-login. No selection means the platform default applies. API",
+            "keys are already organization-bound — none of this applies.",
         ],
     },
     {
@@ -307,6 +316,8 @@ RESULTS: dict[str, dict] = {
             ("endpoint", "its endpoint"),
             ("endpoint_source", "default | config | env"),
             ("identity", "OAuth logins: the token's identity claims"),
+            ("organization", "OAuth logins: the selected organization "
+             "({id, name}; null when the platform default applies)"),
         ],
     },
     "auth status": {
@@ -318,7 +329,27 @@ RESULTS: dict[str, dict] = {
             ("source", "env (ADE_API_KEY) | stored"),
             ("environment / endpoint / endpoint_source", "the resolved target"),
             ("other_environments", "every other environment holding a credential"),
-            ("expires_at / expires_in_seconds / refresh_token", "OAuth only"),
+            ("expires_at / expires_in_seconds / refresh_token / organization",
+             "OAuth only"),
+        ],
+    },
+    "auth org list": {
+        "shape": "object",
+        "keys": [
+            ("organizations", "your memberships, live from the login "
+             "provider: [{id, name, selected}]"),
+            ("selected", "the selected organization id (null when the "
+             "platform default applies)"),
+            ("environment", "the resolved target"),
+        ],
+    },
+    "auth org switch": {
+        "shape": "object",
+        "keys": [
+            ("organization", "the selection now stored ({id, name})"),
+            ("previous", "the selection it replaced (null if none)"),
+            ("stored", "always true on success"),
+            ("environment", "the resolved target"),
         ],
     },
     "auth logout": {

--- a/src/ade_cli/help.py
+++ b/src/ade_cli/help.py
@@ -145,8 +145,10 @@ TOPICS: list[dict] = [
             "membership selects itself; several prompt at login (or take",
             "--org). `ade auth org list` shows the memberships live, and",
             "`ade auth org switch <org>` changes the selection without a",
-            "re-login. No selection means the platform default applies. API",
-            "keys are already organization-bound — none of this applies.",
+            "re-login. Requests run — and bill — in the selected",
+            "organization; none selected means the platform default applies.",
+            "An API key needs no selection and accepts none: it acts in the",
+            "organization it was created in.",
         ],
     },
     {

--- a/src/ade_cli/oauth.py
+++ b/src/ade_cli/oauth.py
@@ -291,7 +291,19 @@ def _post_token(
         except (json.JSONDecodeError, AttributeError):
             detail = response.text
         raise _TokenEndpointError(response.status_code, str(detail))
-    return response.json()
+    # A 200 whose body is not a JSON object is still a broken answer, and
+    # every caller translates _TokenEndpointError into its own flow's
+    # failure — so normalizing here is what keeps a malformed response
+    # from escaping as a decode error nobody catches.
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise _TokenEndpointError(200, f"response body was not JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise _TokenEndpointError(
+            200, f"response body was {type(payload).__name__}, not a JSON object"
+        )
+    return payload
 
 
 def _entry_from(payload: dict, *, clock: Clock, previous: dict | None) -> dict:
@@ -415,13 +427,28 @@ def fetch_organizations(home: Path, environment: str, ports: Ports) -> list[dict
         raise OrgDiscoveryError(
             "userinfo", f"userinfo answered {response.status_code}"
         )
-    claims = response.json()
+    try:
+        claims = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise OrgDiscoveryError(
+            "userinfo", f"userinfo body was not JSON: {error}"
+        ) from error
+    if not isinstance(claims, dict):
+        raise OrgDiscoveryError(
+            "userinfo",
+            f"userinfo body was {type(claims).__name__}, not a JSON object",
+        )
     if "organizations" not in claims:
         # The refresh token predates the organizations scope: userinfo
         # omits the claim entirely (an empty membership list would be []).
         raise OrgDiscoveryError(
             "relogin_required",
             "this session predates organization support — log out and back in",
+        )
+    memberships = claims.get("organizations") or []
+    if not isinstance(memberships, list):
+        raise OrgDiscoveryError(
+            "userinfo", "userinfo carried a malformed organizations claim"
         )
     named = {
         item.get("id"): item
@@ -430,7 +457,8 @@ def fetch_organizations(home: Path, environment: str, ports: Ports) -> list[dict
     }
     return [
         {"id": org_id, "name": (named.get(org_id) or {}).get("name") or org_id}
-        for org_id in claims.get("organizations") or []
+        for org_id in memberships
+        if isinstance(org_id, str) and org_id
     ]
 
 

--- a/src/ade_cli/oauth.py
+++ b/src/ade_cli/oauth.py
@@ -12,7 +12,10 @@ Logto specifics encoded here: ``prompt=consent`` + ``offline_access`` are
 what earns a refresh token; refresh tokens rotate on every use (so refresh
 holds a cross-process lock and re-reads before spending one); and a JWT
 access token bound to the ADE API audience requires the RFC 8707
-``resource`` indicator — without it Logto mints an opaque token.
+``resource`` indicator — without it Logto mints an opaque token. That
+last rule is why organization discovery (ADR-0009) spends a refresh with
+no resource: only the opaque token is welcome at userinfo, where the
+organization claims live.
 """
 
 from __future__ import annotations
@@ -36,7 +39,10 @@ from .config import ENVIRONMENTS, ResolvedConfig, load_config
 from .gateway import BearerAuth, GatewayError, StaticBearer
 from .ports import Clock, Ports
 
-SCOPES = "openid profile email offline_access"
+# urn:logto:scope:organizations makes userinfo return the user's
+# organization memberships (the ``organizations`` / ``organization_data``
+# claims) — the discovery behind the login org picker (ADR-0009).
+SCOPES = "openid profile email offline_access urn:logto:scope:organizations"
 LOGIN_TIMEOUT_SECONDS = 300.0
 EXPIRY_SKEW_SECONDS = 60.0  # refresh this close to expiry, not at it
 _POLL_TICK_SECONDS = 0.2
@@ -81,6 +87,10 @@ class Provider:
     @property
     def revocation_endpoint(self) -> str:
         return f"{self.issuer}/token/revocation"
+
+    @property
+    def userinfo_endpoint(self) -> str:
+        return f"{self.issuer}/me"
 
 
 def resolve_provider(home: Path, environment: str) -> Provider:
@@ -289,7 +299,7 @@ def _entry_from(payload: dict, *, clock: Clock, previous: dict | None) -> dict:
     if not access_token:
         raise _TokenEndpointError(200, "response carried no access_token")
     expires_in = float(payload.get("expires_in") or 3600.0)
-    return {
+    entry = {
         "access_token": access_token,
         # Rotation: Logto invalidates the spent refresh token; when a
         # response omits a new one (spec-legal), the previous stays valid.
@@ -298,6 +308,12 @@ def _entry_from(payload: dict, *, clock: Clock, previous: dict | None) -> dict:
         "expires_at": clock.now() + expires_in,
         "identity": _identity(payload) or (previous or {}).get("identity") or {},
     }
+    # The org selection is CLI state, never in a token response — it
+    # survives every refresh until set_organization changes it.
+    organization = (previous or {}).get("organization")
+    if organization:
+        entry["organization"] = organization
+    return entry
 
 
 def _identity(payload: dict) -> dict | None:
@@ -313,6 +329,133 @@ def _identity(payload: dict) -> dict | None:
     except (IndexError, ValueError):
         return None
     return {k: claims[k] for k in ("sub", "email", "name") if claims.get(k)}
+
+
+class OrgDiscoveryError(Exception):
+    """Organization discovery or selection failed; ``reason`` is
+    machine-readable. Never raised by the login flow itself — callers
+    decide whether a failure blocks (an explicit --org) or degrades to
+    the platform default (the automatic post-login pick)."""
+
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+
+
+def fetch_organizations(home: Path, environment: str, ports: Ports) -> list[dict]:
+    """The stored session's Logto organization memberships, as
+    ``[{"id", "name"}, ...]`` from the userinfo claims (ADR-0009).
+
+    The stored access token is audience-bound to the ADE API (RFC 8707),
+    which userinfo rejects, so this spends one refresh WITHOUT the
+    resource indicator to mint a userinfo-capable token. The rotated
+    refresh token is persisted under the cross-process lock; the stored
+    API access token (still live) is left untouched. Raises
+    OrgDiscoveryError; never changes the stored selection."""
+    provider = resolve_provider(home, environment)
+    if not provider.client_id:
+        raise OrgDiscoveryError(
+            "not_configured", f"OAuth is not configured for {environment}"
+        )
+    with credentials.refresh_lock(home):
+        stored = credentials.load_stored(home) or {}
+        entry = credentials.oauth_entry(
+            (stored.get("environments") or {}).get(environment)
+        )
+        if entry is None:
+            raise OrgDiscoveryError(
+                "no_session", "no OAuth session is stored for this environment"
+            )
+        refresh_token = entry.get("refresh_token")
+        if not refresh_token:
+            raise OrgDiscoveryError(
+                "no_refresh_token", "the stored session has no refresh token"
+            )
+        try:
+            payload = _post_token(
+                ports.transport,
+                provider,
+                {
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": provider.client_id,
+                },
+            )
+        except _TokenEndpointError as error:
+            raise OrgDiscoveryError("token_endpoint", str(error)) from error
+        except httpx.HTTPError as error:
+            raise OrgDiscoveryError(
+                "unreachable", f"could not reach the login provider ({error})"
+            ) from error
+        if payload.get("refresh_token"):
+            credentials.store_oauth(
+                home,
+                environment,
+                {**entry, "refresh_token": payload["refresh_token"]},
+            )
+    userinfo_token = payload.get("access_token")
+    if not userinfo_token:
+        raise OrgDiscoveryError(
+            "token_endpoint", "refresh response carried no access_token"
+        )
+    try:
+        with httpx.Client(
+            transport=ports.transport, timeout=_TOKEN_TIMEOUT_SECONDS
+        ) as client:
+            response = client.get(
+                provider.userinfo_endpoint,
+                headers={"Authorization": f"Bearer {userinfo_token}"},
+            )
+    except httpx.HTTPError as error:
+        raise OrgDiscoveryError(
+            "unreachable", f"could not reach the login provider ({error})"
+        ) from error
+    if response.status_code != 200:
+        raise OrgDiscoveryError(
+            "userinfo", f"userinfo answered {response.status_code}"
+        )
+    claims = response.json()
+    if "organizations" not in claims:
+        # The refresh token predates the organizations scope: userinfo
+        # omits the claim entirely (an empty membership list would be []).
+        raise OrgDiscoveryError(
+            "relogin_required",
+            "this session predates organization support — log out and back in",
+        )
+    named = {
+        item.get("id"): item
+        for item in claims.get("organization_data") or []
+        if isinstance(item, dict) and item.get("id")
+    }
+    return [
+        {"id": org_id, "name": (named.get(org_id) or {}).get("name") or org_id}
+        for org_id in claims.get("organizations") or []
+    ]
+
+
+def set_organization(home: Path, environment: str, organization: dict | None) -> None:
+    """Persist the org selection on the stored OAuth session (None
+    clears it). The selection rides ``x-org-id`` on API requests, where
+    the platform verifies membership per request (ADR-0009)."""
+    with credentials.refresh_lock(home):
+        stored = credentials.load_stored(home) or {}
+        entry = credentials.oauth_entry(
+            (stored.get("environments") or {}).get(environment)
+        )
+        if entry is None:
+            raise OrgDiscoveryError(
+                "no_session", "no OAuth session is stored for this environment"
+            )
+        entry = dict(entry)
+        if organization is None:
+            entry.pop("organization", None)
+        else:
+            entry["organization"] = {
+                "id": organization["id"],
+                "name": organization.get("name") or organization["id"],
+            }
+        credentials.store_oauth(home, environment, entry)
 
 
 def revoke_stored(home: Path, transport: httpx.BaseTransport) -> int:

--- a/src/ade_cli/parse.py
+++ b/src/ade_cli/parse.py
@@ -207,6 +207,7 @@ def parse(
         auth=oauth.bearer_auth(home, resolved, active, ports),
         transport=ports.transport,
         command="parse",
+        org_id=active.org_id,
     )
     jobs = store.JobStore(home)
     # --options is the full ParseOptions object, passed through verbatim —

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -12,6 +12,7 @@ import stat
 from urllib.parse import parse_qs, urlparse
 from urllib.request import urlopen
 
+import httpx
 import pytest
 
 from parse_fixtures import completed_job
@@ -1097,3 +1098,241 @@ def test_refresh_preserves_the_org_selection(cli, tmp_path):
     assert submit.headers["x-org-id"] == "org-a"
     entry = stored_environments(cli)["production"]
     assert entry["oauth"]["organization"] == ORG_A
+
+
+# --- Review follow-ups: malformed provider answers, contract parity,
+# --- and a selection that outlived its membership
+
+
+def test_login_survives_a_malformed_discovery_token_response(cli):
+    # Discovery is best-effort by contract (ADR-0009): a token endpoint
+    # answering 200 with a non-JSON body must not cost the login.
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond_with(
+        lambda request: httpx.Response(200, content=b"<html>gateway</html>")
+    )
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["organization"] is None
+    assert "not JSON" in payload["organization_note"]
+    assert stored_environments(cli)["production"]["oauth"]["access_token"] == "at-1"
+
+
+def test_login_survives_a_non_object_discovery_token_response(cli):
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond(200, ["not", "an", "object"])
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["organization"] is None
+    assert stored_environments(cli)["production"]["oauth"]["access_token"] == "at-1"
+
+
+def test_login_survives_a_malformed_userinfo_body(cli):
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond(200, token_response(access="opaque-1", refresh="rt-2"))
+    cli.transport.respond_with(
+        lambda request: httpx.Response(200, content=b"not json at all")
+    )
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["organization"] is None
+    assert "ade auth org switch" in payload["organization_note"]
+    assert stored_environments(cli)["production"]["oauth"]["access_token"] == "at-1"
+
+
+def test_login_survives_a_non_object_userinfo_body(cli):
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond(200, token_response(access="opaque-1", refresh="rt-2"))
+    cli.transport.respond(200, ["claims", "should", "be", "an", "object"])
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["organization"] is None
+
+
+def test_login_survives_a_malformed_organizations_claim(cli):
+    # The claim is present (so not the pre-scope case) but not a list.
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond(200, token_response(access="opaque-1", refresh="rt-2"))
+    cli.transport.respond(200, {"sub": "user-1", "organizations": "org-a"})
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["organization"] is None
+
+
+def test_explicit_org_flag_reports_a_malformed_discovery_answer(cli):
+    # --org asked for a state the login could not reach: that fails
+    # loudly (exit 1) even though the tokens are kept.
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond(200, ["not", "an", "object"])
+
+    result = cli.invoke(
+        "auth", "login", "--org", "org-a", "--json", browser=ClickAllow()
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"].startswith("org_")
+    assert payload["stored"] is True
+    assert stored_environments(cli)["production"]["oauth"]["access_token"] == "at-1"
+
+
+def test_malformed_login_token_response_is_a_clean_failure(cli):
+    # The same normalization guards the login exchange itself: a 200 with
+    # a non-JSON body is a clean LoginError, never a traceback.
+    seed_oauth_config(cli)
+    cli.transport.respond_with(
+        lambda request: httpx.Response(200, content=b"<html>gateway</html>")
+    )
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "oauth_token_endpoint"
+    assert not (cli.home / "credentials.json").exists()
+
+
+def test_already_authenticated_login_publishes_the_organization(cli):
+    # The published `auth login` shape promises `organization` on every
+    # OAuth result — the no-op path included.
+    seed_stored_oauth(cli, organization=ORG_A)
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["already_authenticated"] is True
+    assert payload["organization"] == ORG_A
+    assert cli.transport.requests == []  # still a no-op: no discovery
+
+
+def test_already_authenticated_login_publishes_a_null_organization(cli):
+    seed_stored_oauth(cli)
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["organization"] is None  # the key is present, not omitted
+
+
+def test_org_list_flags_a_selection_that_lost_its_membership(cli):
+    # Removed from the org (or the org is gone): the header still goes
+    # out, so the listing must say so rather than imply the default.
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization={"id": "org-gone", "name": "Gone"})
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke("auth", "org", "list", "--json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["selected"] == "org-gone"
+    assert payload["selected_is_stale"] is True
+    assert not any(row["selected"] for row in payload["organizations"])
+
+
+def test_org_list_stale_human_output_names_both_remediations(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization={"id": "org-gone", "name": "Gone"})
+    script_discovery(cli, orgs=[])
+
+    result = cli.invoke("auth", "org", "list")
+
+    assert result.exit_code == 0, result.output
+    # Never claims the platform default applies while the header persists.
+    assert "no longer one of your memberships" in result.stdout
+    assert "ade auth org switch" in result.stdout
+    assert "ade auth org clear" in result.stdout
+
+
+def test_org_list_live_selection_is_not_stale(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization=ORG_A)
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke("auth", "org", "list", "--json")
+
+    assert json.loads(result.stdout)["selected_is_stale"] is False
+
+
+def test_org_clear_drops_the_selection_without_discovery(cli):
+    # Deliberately offline: clearing is the way out of a stale selection,
+    # which is exactly when listing memberships may not work.
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization={"id": "org-gone", "name": "Gone"})
+
+    result = cli.invoke("auth", "org", "clear", "--json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["cleared"] is True
+    assert payload["organization"] is None
+    assert payload["previous"] == {"id": "org-gone", "name": "Gone"}
+    assert cli.transport.requests == []  # no provider round-trip
+    assert "organization" not in stored_environments(cli)["production"]["oauth"]
+
+
+def test_org_clear_is_idempotent(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli)
+
+    result = cli.invoke("auth", "org", "clear", "--json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["cleared"] is False
+    assert payload["previous"] is None
+
+
+def test_org_clear_requires_an_oauth_session(cli):
+    cli.transport.respond(200, {"accepted": 0})  # the verification probe (#117)
+    cli.invoke("auth", "login", "--api-key", KEY)
+
+    result = cli.invoke("auth", "org", "clear", "--json")
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "org_requires_oauth"
+
+
+def test_cleared_selection_stops_sending_the_header(cli, tmp_path):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization=ORG_A)
+    cli.invoke("auth", "org", "clear")
+    cli.transport.respond(202, {"job_id": "job-0001", "status": "pending"})
+    cli.transport.respond(200, completed_job())
+
+    result = cli.invoke(*_parse_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert "x-org-id" not in cli.transport.requests[0].headers
+
+
+def test_stale_selection_still_rides_requests_until_changed(cli, tmp_path):
+    # The honest half of the stale contract: nothing client-side silently
+    # drops the header, which is why `org list` must warn.
+    seed_stored_oauth(cli, organization={"id": "org-gone", "name": "Gone"})
+    cli.transport.respond(202, {"job_id": "job-0001", "status": "pending"})
+    cli.transport.respond(200, completed_job())
+
+    result = cli.invoke(*_parse_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert cli.transport.requests[0].headers["x-org-id"] == "org-gone"

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -63,6 +63,7 @@ def seed_stored_oauth(
     access: str = "at-old",
     refresh: str | None = "rt-old",
     expires_at: float = 1_750_000_000.0 + 3600,  # FakeClock start + 1h
+    organization: dict | None = None,
 ) -> None:
     cli.home.mkdir(parents=True, exist_ok=True)
     entry = {
@@ -71,9 +72,40 @@ def seed_stored_oauth(
         "expires_at": expires_at,
         "identity": {"sub": "user-1", "email": "zhichao.lin@landing.ai"},
     }
+    if organization is not None:
+        entry["organization"] = organization
     (cli.home / "credentials.json").write_text(
         json.dumps({"environments": {environment: {"method": "oauth", "oauth": entry}}})
     )
+
+
+ORG_A = {"id": "org-a", "name": "Acme"}
+ORG_B = {"id": "org-b", "name": "Beta"}
+
+
+def userinfo_response(orgs: list[dict]) -> dict:
+    """Userinfo claims carrying the organization memberships (ADR-0009)."""
+    return {
+        "sub": "user-1",
+        "email": "zhichao.lin@landing.ai",
+        "organizations": [org["id"] for org in orgs],
+        "organization_data": [
+            {"id": org["id"], "name": org["name"], "description": ""} for org in orgs
+        ],
+    }
+
+
+def script_discovery(
+    cli, orgs: list[dict] | None = None, refresh: str = "rt-2"
+) -> None:
+    """The two requests behind org discovery (ADR-0009): a resource-less
+    refresh minting a userinfo-capable token, then userinfo itself. The
+    default single membership makes the pick automatic — the shape most
+    existing login tests want."""
+    cli.transport.respond(
+        200, token_response(access="opaque-1", refresh=refresh)
+    )
+    cli.transport.respond(200, userinfo_response([ORG_A] if orgs is None else orgs))
 
 
 class ClickAllow:
@@ -108,6 +140,7 @@ def test_login_pkce_flow_stores_tokens_0600(cli):
     seed_oauth_config(cli)
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", browser=browser)
 
@@ -120,30 +153,46 @@ def test_login_pkce_flow_stores_tokens_0600(cli):
     assert q["code_challenge_method"] == "S256"
     assert q["resource"] == "https://api.ade.landing.ai"
     assert "offline_access" in q["scope"]
+    assert "urn:logto:scope:organizations" in q["scope"]
     assert q["prompt"] == "consent"
     assert q["redirect_uri"].startswith("http://127.0.0.1:")
     # The exchange went to the issuer's token endpoint with the matching
     # verifier: S256(code_verifier) must equal the challenge sent above.
-    (exchange,) = cli.transport.requests
+    exchange = cli.transport.requests[0]
     assert str(exchange.url) == "https://login.landing.ai/oidc/token"
     form = {k: v[0] for k, v in parse_qs(exchange.content.decode()).items()}
     assert form["grant_type"] == "authorization_code"
     assert form["code"] == "code-1"
     challenge = _b64url(hashlib.sha256(form["code_verifier"].encode()).digest())
     assert challenge == q["code_challenge"]
-    # Tokens stored per environment, file locked down.
+    # Org discovery followed (ADR-0009): a resource-less refresh (the
+    # userinfo-capable token), then userinfo itself.
+    discovery = cli.transport.requests[1]
+    discovery_form = {
+        k: v[0] for k, v in parse_qs(discovery.content.decode()).items()
+    }
+    assert discovery_form["grant_type"] == "refresh_token"
+    assert "resource" not in discovery_form
+    userinfo = cli.transport.requests[2]
+    assert str(userinfo.url) == "https://login.landing.ai/oidc/me"
+    assert userinfo.headers["Authorization"] == "Bearer opaque-1"
+    # Tokens stored per environment, file locked down. The discovery
+    # refresh rotated the refresh token; the API access token is intact.
     creds = cli.home / "credentials.json"
     assert stat.S_IMODE(creds.stat().st_mode) == 0o600
     entry = stored_environments(cli)["production"]
     assert entry["method"] == "oauth"
     assert entry["oauth"]["access_token"] == "at-1"
-    assert entry["oauth"]["refresh_token"] == "rt-1"
+    assert entry["oauth"]["refresh_token"] == "rt-2"
     assert entry["oauth"]["identity"]["email"] == "zhichao.lin@landing.ai"
+    # The single membership selected itself.
+    assert entry["oauth"]["organization"] == ORG_A
 
 
 def test_login_json_reports_identity_without_leaking_tokens(cli):
     seed_oauth_config(cli)
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
 
@@ -151,13 +200,16 @@ def test_login_json_reports_identity_without_leaking_tokens(cli):
     payload = json.loads(result.stdout)
     assert payload["method"] == "oauth"
     assert payload["identity"]["email"] == "zhichao.lin@landing.ai"
+    assert payload["organization"] == ORG_A
     assert "at-1" not in result.stdout
+    assert "opaque-1" not in result.stdout
 
 
 def test_login_targets_the_env_flag(cli):
     seed_oauth_config(cli, environment="dev")
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", "--env", "dev", browser=browser)
 
@@ -196,6 +248,7 @@ def test_flagless_browser_login_targets_production_despite_stale_config_keys(cli
     )
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", "--json", browser=browser)
 
@@ -214,14 +267,17 @@ def test_login_config_overrides_issuer_and_resource(cli):
     )
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", browser=browser)
 
     assert result.exit_code == 0
     assert browser.url.startswith("https://login.example.test/oidc/auth?")
     assert browser.query()["resource"] == "https://api.example.test"
-    (exchange,) = cli.transport.requests
+    exchange = cli.transport.requests[0]
     assert str(exchange.url) == "https://login.example.test/oidc/token"
+    # Discovery derives its endpoints from the same overridden issuer.
+    assert str(cli.transport.requests[2].url) == "https://login.example.test/oidc/me"
 
 
 def test_login_denied_errors_cleanly_without_tokens(cli):
@@ -254,6 +310,7 @@ def test_forged_state_is_ignored_and_never_exchanged(cli):
 def test_stray_probe_does_not_kill_the_login(cli):
     seed_oauth_config(cli)
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     class ProbeThenAllow(ClickAllow):
         def __call__(self, url: str) -> bool:
@@ -288,6 +345,7 @@ class ClickAllowReadingPage(ClickAllow):
 def test_callback_page_is_the_branded_success_landing(cli):
     seed_oauth_config(cli)
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
     browser = ClickAllowReadingPage()
 
     result = cli.invoke("auth", "login", browser=browser)
@@ -344,6 +402,7 @@ def test_arrow_menu_down_enter_picks_the_browser(cli):
     cli.stdin_tty = True
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke(
         "auth", "login", "--json",
@@ -369,6 +428,7 @@ def test_menu_browser_choice_ignores_a_stale_stored_endpoint(cli):
     cli.stdin_tty = True
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke(
         "auth", "login", "--json",
@@ -406,6 +466,7 @@ def test_tty_menu_choice_2_runs_the_browser_flow(cli):
     cli.stdin_tty = True
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke(
         "auth", "login", "--json", input="2\n", browser=browser,
@@ -425,6 +486,7 @@ def test_non_tty_login_skips_the_menu_and_goes_to_browser(cli):
     # browser flow, exactly the pre-menu behavior.
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", "--json", browser=browser)
 
@@ -495,6 +557,7 @@ def test_tty_menu_offers_browser_under_ade_endpoint_with_a_resource(cli):
     cli.stdin_tty = True
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke(
         "auth", "login", "--json",
@@ -523,6 +586,7 @@ BAKED_CLIENT_IDS = {
 def test_every_environment_logs_in_with_no_config_at_all(cli, environment):
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", "--env", environment, browser=browser)
 
@@ -552,6 +616,7 @@ def test_config_client_id_overrides_the_baked_default(cli):
     seed_oauth_config(cli, environment="dev")  # seeds CLIENT_ID, not the baked id
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke("auth", "login", "--env", "dev", browser=browser)
 
@@ -607,6 +672,7 @@ def test_browser_login_under_ade_endpoint_with_resource_override_proceeds(cli):
     )
     browser = ClickAllow()
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
 
     result = cli.invoke(
         "auth", "login",
@@ -621,6 +687,7 @@ def test_browser_login_under_ade_endpoint_with_resource_override_proceeds(cli):
 def test_status_shows_oauth_identity_and_expiry(cli):
     seed_oauth_config(cli)
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
     cli.invoke("auth", "login", browser=ClickAllow())
 
     result = cli.invoke("auth", "status", "--json")
@@ -637,6 +704,7 @@ def test_status_shows_oauth_identity_and_expiry(cli):
 def test_status_human_output_names_the_identity(cli):
     seed_oauth_config(cli)
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
     cli.invoke("auth", "login", browser=ClickAllow())
 
     result = cli.invoke("auth", "status")
@@ -644,6 +712,7 @@ def test_status_human_output_names_the_identity(cli):
     assert result.exit_code == 0
     assert "zhichao.lin@landing.ai" in result.stdout
     assert "expires" in result.stdout
+    assert "Acme (org-a)" in result.stdout
 
 
 def test_env_api_key_still_wins_over_stored_oauth(cli):
@@ -659,6 +728,7 @@ def test_env_api_key_still_wins_over_stored_oauth(cli):
 def test_most_recent_login_wins_api_key_after_oauth(cli):
     seed_oauth_config(cli)
     cli.transport.respond(200, token_response())
+    script_discovery(cli)
     cli.invoke("auth", "login", browser=ClickAllow())
 
     cli.transport.respond(200, {"accepted": 0})  # the verification probe (#117)
@@ -789,3 +859,241 @@ def test_api_key_requests_never_touch_the_token_endpoint(cli, tmp_path):
     assert result.exit_code == 0, result.output
     _probe, submit, poll = cli.transport.requests
     assert submit.headers["Authorization"] == f"Bearer {KEY}"
+
+
+# --- Organization selection (ADR-0009): discovery, the pick, x-org-id ---
+
+
+def test_login_multiple_orgs_prompts_with_arrows(cli):
+    seed_oauth_config(cli)
+    cli.stderr_tty = True
+    cli.stdin_tty = True
+    cli.transport.respond(200, token_response())
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke(
+        "auth", "login", "--json",
+        # Method menu: down + Enter picks the browser; org menu: down +
+        # Enter picks the second membership.
+        keys=["\x1b[B", "\r", "\x1b[B", "\r"],
+        env={"TERM": "xterm-256color"},
+        browser=ClickAllow(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Which organization" in result.stderr
+    assert json.loads(result.stdout)["organization"] == ORG_B
+    entry = stored_environments(cli)["production"]
+    assert entry["oauth"]["organization"] == ORG_B
+
+
+def test_login_multiple_orgs_non_interactive_defers_to_platform_default(cli):
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["organization"] is None
+    assert "organization" not in stored_environments(cli)["production"]["oauth"]
+    # The remediation names the switch command, in the payload agents read.
+    assert "ade auth org switch" in payload["organization_note"]
+
+
+def test_login_org_flag_picks_by_name_without_a_prompt(cli):
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke(
+        "auth", "login", "--org", "beta", "--json", browser=ClickAllow()
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["organization"] == ORG_B
+    entry = stored_environments(cli)["production"]
+    assert entry["oauth"]["organization"] == ORG_B
+
+
+def test_login_org_flag_unknown_fails_but_keeps_the_login(cli):
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke(
+        "auth", "login", "--org", "nope", "--json", browser=ClickAllow()
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "org_not_found"
+    # The listing names what the account can act in.
+    assert any(org["id"] == "org-a" for org in payload["organizations"])
+    # The login itself survived: tokens stored, no selection.
+    entry = stored_environments(cli)["production"]
+    assert entry["oauth"]["access_token"] == "at-1"
+    assert "organization" not in entry["oauth"]
+
+
+def test_login_org_flag_with_api_key_is_a_usage_error(cli):
+    result = cli.invoke(
+        "auth", "login", "--api-key", KEY, "--org", "org-a", "--json"
+    )
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["error"] == "org_with_api_key"
+    assert cli.transport.requests == []
+
+
+def test_login_org_flag_switches_an_existing_session_without_a_browser(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization=ORG_A)
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+    browser = ClickAllow()
+
+    result = cli.invoke(
+        "auth", "login", "--org", "org-b", "--json", browser=browser
+    )
+
+    assert result.exit_code == 0, result.output
+    assert browser.url is None  # ensure semantics: no browser round-trip
+    payload = json.loads(result.stdout)
+    assert payload["already_authenticated"] is True
+    assert payload["organization"] == ORG_B
+    entry = stored_environments(cli)["production"]
+    assert entry["oauth"]["organization"] == ORG_B
+    # The discovery refresh rotated the refresh token; persisted.
+    assert entry["oauth"]["refresh_token"] == "rt-2"
+    assert entry["oauth"]["access_token"] == "at-old"  # API token untouched
+
+
+def test_login_session_predating_the_org_scope_notes_relogin(cli):
+    # Userinfo omits the organizations claim entirely when the refresh
+    # token was granted before the scope existed — the login still lands.
+    seed_oauth_config(cli)
+    cli.transport.respond(200, token_response())
+    cli.transport.respond(200, token_response(access="opaque-1", refresh="rt-2"))
+    cli.transport.respond(200, {"sub": "user-1", "email": "zhichao.lin@landing.ai"})
+
+    result = cli.invoke("auth", "login", "--json", browser=ClickAllow())
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["organization"] is None
+    assert stored_environments(cli)["production"]["oauth"]["access_token"] == "at-1"
+
+
+def test_org_list_marks_the_selected_membership(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization=ORG_B)
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke("auth", "org", "list", "--json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["selected"] == "org-b"
+    assert payload["organizations"] == [
+        {"id": "org-a", "name": "Acme", "selected": False},
+        {"id": "org-b", "name": "Beta", "selected": True},
+    ]
+
+
+def test_org_switch_updates_the_stored_selection(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization=ORG_A)
+    script_discovery(cli, orgs=[ORG_A, ORG_B])
+
+    result = cli.invoke("auth", "org", "switch", "Beta", "--json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["organization"] == ORG_B
+    assert payload["previous"] == ORG_A
+    entry = stored_environments(cli)["production"]
+    assert entry["oauth"]["organization"] == ORG_B
+
+
+def test_org_switch_unknown_lists_the_memberships(cli):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli)
+    script_discovery(cli, orgs=[ORG_A])
+
+    result = cli.invoke("auth", "org", "switch", "org-x", "--json")
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "org_not_found"
+    assert "organization" not in stored_environments(cli)["production"]["oauth"]
+
+
+def test_org_commands_require_an_oauth_session(cli):
+    cli.transport.respond(200, {"accepted": 0})  # the verification probe (#117)
+    cli.invoke("auth", "login", "--api-key", KEY)
+
+    result = cli.invoke("auth", "org", "list", "--json")
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "org_requires_oauth"
+
+
+def test_org_list_unauthenticated_points_at_login(cli):
+    result = cli.invoke("auth", "org", "list", "--json")
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["error"] == "unauthenticated"
+
+
+def test_parse_sends_the_selected_org_header(cli, tmp_path):
+    seed_stored_oauth(cli, organization=ORG_A)
+    cli.transport.respond(202, {"job_id": "job-0001", "status": "pending"})
+    cli.transport.respond(200, completed_job())
+
+    result = cli.invoke(*_parse_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    submit, poll = cli.transport.requests
+    assert submit.headers["x-org-id"] == "org-a"
+    assert poll.headers["x-org-id"] == "org-a"
+
+
+def test_parse_without_a_selection_sends_no_org_header(cli, tmp_path):
+    seed_stored_oauth(cli)
+    cli.transport.respond(202, {"job_id": "job-0001", "status": "pending"})
+    cli.transport.respond(200, completed_job())
+
+    result = cli.invoke(*_parse_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    submit, _poll = cli.transport.requests
+    assert "x-org-id" not in submit.headers
+
+
+def test_api_key_requests_send_no_org_header(cli, tmp_path):
+    cli.transport.respond(200, {"accepted": 0})  # the verification probe (#117)
+    cli.invoke("auth", "login", "--api-key", KEY)
+    cli.transport.respond(202, {"job_id": "job-0001", "status": "pending"})
+    cli.transport.respond(200, completed_job())
+
+    result = cli.invoke(*_parse_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert "x-org-id" not in cli.transport.requests[1].headers
+
+
+def test_refresh_preserves_the_org_selection(cli, tmp_path):
+    seed_oauth_config(cli)
+    seed_stored_oauth(cli, organization=ORG_A, expires_at=1_750_000_000.0 - 10)
+    cli.transport.respond(200, token_response(access="at-2", refresh="rt-2"))
+    cli.transport.respond(202, {"job_id": "job-0001", "status": "pending"})
+    cli.transport.respond(200, completed_job())
+
+    result = cli.invoke(*_parse_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    _refresh, submit, _poll = cli.transport.requests
+    assert submit.headers["Authorization"] == "Bearer at-2"
+    assert submit.headers["x-org-id"] == "org-a"
+    entry = stored_environments(cli)["production"]
+    assert entry["oauth"]["organization"] == ORG_A

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -221,6 +221,7 @@ def test_help_scopes_to_one_command(cli):
         "auth logout",
         "auth org list",
         "auth org switch",
+        "auth org clear",
     ]
 
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -219,6 +219,8 @@ def test_help_scopes_to_one_command(cli):
         "auth login",
         "auth status",
         "auth logout",
+        "auth org list",
+        "auth org switch",
     ]
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -43,6 +43,7 @@ def test_the_walked_tree_matches_the_expected_commands():
         [
             ("auth", "login"),
             ("auth", "logout"),
+            ("auth", "org", "clear"),
             ("auth", "org", "list"),
             ("auth", "org", "switch"),
             ("auth", "status"),

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -43,6 +43,8 @@ def test_the_walked_tree_matches_the_expected_commands():
         [
             ("auth", "login"),
             ("auth", "logout"),
+            ("auth", "org", "list"),
+            ("auth", "org", "switch"),
             ("auth", "status"),
             ("crop",),
             ("extract",),


### PR DESCRIPTION
## Summary

Browser OAuth logins were organization-blind: the CLI requested no organization at the token grant, so multi-org accounts always landed on the platform-side default (`migratedOrgId`) with no way to choose. This adds organization selection and switching, carried as the `x-org-id` header the platform authz already honors and membership-verifies for user-scoped tokens.

- **Login**: requests `urn:logto:scope:organizations` and discovers memberships via Logto userinfo. One subtlety: the API access token is audience-bound (RFC 8707) and userinfo rejects it, so discovery spends one resource-less refresh to mint the opaque token userinfo accepts — persisting the rotated refresh token under the existing cross-process lock, leaving the API token untouched.
- **Selection**: one membership selects itself silently; several prompt on a terminal (arrow-key picker with a typed fallback, same widget as the login-method menu) or take `--org <id-or-name>`. Discovery failure never fails a login — the platform default applies with a remediation note in both the human text and the JSON payload.
- **New commands**: `ade auth org list` (live memberships, selected one marked) and `ade auth org switch <org>` — no browser round-trip, since the refresh token is org-agnostic. `ade auth login --org X` on an already-authenticated target switches in place, keeping login's guarantee semantics.
- **Wire**: the stored selection rides `x-org-id` on every parse/extract request and survives token refreshes. API keys send no header — they are already organization-bound.
- **Docs**: ADR-0009 records the header-vs-organization-token trade-off and the flip condition; CONTEXT.md glossary, README, SKILL.md, and the `ade help credentials` topic updated.

## Why the header, not Logto organization tokens

Logto supports org-bound tokens (`organization_id` at the token grant, membership enforced at mint, org in a signed claim). That is the better end state, but platform authz does not read the claim yet, so it would need a server change to ship. The header needs none: `checkAuthHeader` routes JWT-shaped bearers through `verifyLogtoAccessToken` (JWKS signature, `iss`, `aud`, `typ: at+jwt`), then resolves the org from `x-org-id` via `fetchOrgContextForUser`, which hard-verifies membership (403 otherwise) and gates on that org's subscription and credit balance.

The two approaches share all the CLI work and differ only in transport, so this does not paint us into a corner. ADR-0009 records the flip condition: when authz reads the `organization_id` claim, swap the header for the grant parameter — nothing user-visible changes.

## Live verification (dev)

Same user, same OIDC token, only the header changed:

| Selected org | Result |
|---|---|
| `ctplkf4kvkjs` | 403 "Organization subscription has expired" — that org's subscription gate fired |
| `hpblrpj3suw4` | parsed, 1.1 credits (`parse-01kzd2cwqt9m5wsjr24rfz2j8b`) |
| `cxwau16ra4zh` | parsed, 1.1 credits (`parse-01kzd2d8zkx84g37xpmhgmebdv`) |

Two fresh, uncached parses billed to two different organizations. Also exercised live: scope acceptance by dev Logto, userinfo discovery (3 real memberships), the ambiguous-name guard (two identically-named orgs), switch by id, `login --org` preselect, and the non-interactive deferral note.

## Notes for reviewers

- The platform's shadow authz service (`apps/authz` in vision-agent-ui, currently compare-only) ignores `x-org-id`. No runtime effect today, but every org-header request will show as a comparison divergence, and it must be ported before that service becomes the enforcer. Flagged in ADR-0009 — worth a heads-up to the platform team.
- Job-item identity is environment + invocation, not organization: re-running the same invocation after an org switch joins the recorded run instead of re-billing under the new org. Arguably correct (no double billing), but it means the cache can serve a run attributed to the previous org. Documented in SKILL.md; possible follow-up decision.
- An API key stores and sends no organization, and the CLI cannot report which org a key acts in — the platform has no introspection route for M2M credentials. The docs now say "the organization it was created in"; a platform endpoint would be needed to display it.

## Test plan

- 722 offline tests pass (34 new/updated: discovery, the picker, `--org` matching and the ambiguity guard, guarantee switch, header on submit and poll, refresh preservation, api-key isolation).
- `ruff check` and `uvx ty check src` clean; `docs/reference/help.json` regenerated.
- Live dev run as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
