### PR TITLE
chore: bump version to 1.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ade-cli"
-version = "1.0.4"
+version = "1.0.5"
 description = "CLI for Agentic Document Extraction (ADE) — parse and extract documents with the v2 APIs, backed by a local store"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ade-cli"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bumps `pyproject.toml` and `uv.lock` to 1.0.5 (minimal two-line diff; the lockfile edit is validated by `uv sync --locked`, full suite green, `ade version` reports 1.0.5).

## ⚠️ Merge order

**Merge #183 first, then this PR** — v1.0.5 is intended to include:

- #183 — feat: organization selection for browser OAuth logins via `x-org-id` (ADR-0009)

Once #183 is in, cut the release via **Actions → Release → "Run workflow"** on `main`. The pipeline runs the live integration suite (macOS + Windows, against production) before tagging `v1.0.5`.

## Release note candidate

Browser (OAuth) sign-in now acts in a chosen organization: a single membership is selected automatically, several prompt at login (or take `--org`), and `ade auth org list` / `ade auth org switch` manage the selection afterwards without a re-login. Requests — and credits — go to the selected organization. API-key logins are unaffected; a key already acts in the organization it was created in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
